### PR TITLE
docs(repo): add contribution guidelines, changelog, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+PR title must be a conventional commit: type(scope): description
+Examples:
+  feat(djf.io): add dark mode toggle
+  fix(calendar-visualizer): correct holiday offset
+  chore(tooling): upgrade biome to 2.5
+  docs(repo): update contributing guidelines
+
+Types: feat, fix, refactor, docs, chore, test
+Scopes: djf.io, calendar-visualizer, ravrun, tooling, docs, repo
+-->
+
+## Summary
+
+<!-- One or two sentences describing what this PR does and why. -->
+
+## Changes
+
+<!-- Bulleted list of specific changes. -->
+
+-
+
+## Changelog entry
+
+<!-- Copy this into docs/changelog/YYYY-MM.md under the correct date heading. -->
+
+```markdown
+### type(scope): description
+
+Summary of what changed and why.
+```
+
+## Testing
+
+<!-- How were these changes verified? -->
+
+- [ ] Builds successfully
+- [ ] Tests pass
+- [ ] Manually verified

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agents
+
+Entry point for AI coding agents operating on this repository.
+
+## Repository overview
+
+Personal monorepo containing web applications, exercises, and configuration. No pnpm workspace -- apps have independent lockfiles and dependencies. Shared dev tooling is managed via mise.
+
+## Key paths
+
+| Path | Description |
+|------|-------------|
+| `apps/djf.io/` | Personal site (Astro, MDX, PandaCSS, React) |
+| `apps/calendar-visualizer/` | Calendar visualization app (Astro, PandaCSS, React) |
+| `apps/ravrun/` | Web app (Vite, TanStack Router, React) |
+| `docs/` | Project documentation and changelog |
+| `.config/` | Shared tooling config (mise, cspell) |
+
+## Conventions
+
+- **Commits/PRs:** [Conventional commits](https://www.conventionalcommits.org/) for PR titles
+- **Naming:** Lowercase kebab-case for all directories and documentation files
+- **No emojis** in code, commits, or documentation
+- **Tooling:** Biome (JS/TS/CSS/JSON), Oxlint, Prettier (MD/MDX only), cspell
+
+## References
+
+- [CLAUDE.md](CLAUDE.md) -- Claude Code-specific guidelines, documentation standards, app details
+- [CONTRIBUTING.md](CONTRIBUTING.md) -- PR workflow, changelog process, code conventions
+- [docs/changelog/](docs/changelog/) -- monthly change history
+- [docs/projects.md](docs/projects.md) -- active project index
+
+## Per-app agent docs
+
+- [apps/calendar-visualizer/AGENTS.md](apps/calendar-visualizer/AGENTS.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,12 @@ Each progress file should contain:
 - Next steps
 - Any blockers or open questions
 
+## Related Docs
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) -- PR workflow, changelog process, code conventions
+- [AGENTS.md](AGENTS.md) -- universal AI agent entry point
+- [docs/changelog/](docs/changelog/) -- monthly change history
+
 ## Monorepo Structure
 
 - `apps/` - Application projects (djf.io, calendar-visualizer, ravrun)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+This document is primarily for AI agents (Claude Code, GitHub Copilot) that operate on this repository. Human contributors should also follow these conventions.
+
+## PR workflow
+
+1. Create a feature branch
+2. Make changes following the conventions below
+3. Open a PR with a [conventional commit](https://www.conventionalcommits.org/) title
+4. Add a changelog entry to `docs/changelog/YYYY-MM.md`
+
+### PR title format
+
+```
+type(scope): description
+```
+
+**Types:** `feat`, `fix`, `refactor`, `docs`, `chore`, `test`
+
+**Scopes:** `djf.io`, `calendar-visualizer`, `ravrun`, `tooling`, `docs`, `repo`
+
+### Changelog
+
+Add an entry to the current month's file in `docs/changelog/`. See [docs/changelog/README.md](docs/changelog/README.md) for format details.
+
+## Code conventions
+
+- No emojis in code, commits, or documentation
+- Follow existing patterns in the codebase
+- Use tooling defined in `.config/mise.toml` (Biome, Oxlint, Prettier)
+- See per-app `package.json` scripts for lint/format/spell commands
+
+## Documentation conventions
+
+All project documentation follows the structure defined in [CLAUDE.md](CLAUDE.md):
+- Project plans and progress in `docs/projects/<project-name>/`
+- Lowercase kebab-case naming for all doc directories and files
+- Progress files named `YYYY-MM-DD-progress.md`
+
+## References
+
+- [CLAUDE.md](CLAUDE.md) -- project documentation standards, monorepo structure, tooling
+- [AGENTS.md](AGENTS.md) -- AI agent entry point with repo overview
+- [docs/changelog/](docs/changelog/) -- change history
+- [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) -- PR template

--- a/docs/changelog/2026-02.md
+++ b/docs/changelog/2026-02.md
@@ -1,0 +1,19 @@
+# 2026-02
+
+## 2026-02-24
+
+### docs(repo): add contribution guidelines, changelog, and PR template
+
+Created CONTRIBUTING.md, AGENTS.md, and PR template. Established monthly changelog structure under docs/changelog/. Updated CLAUDE.md with cross-references.
+
+## 2026-02-21
+
+### chore(tooling): consolidate dev tooling to root-level mise
+
+Migrated Biome, Oxlint, and Prettier from per-app devDependencies to mise-managed root tooling. Upgraded Biome to 2.4 schema and Oxlint to 1.x. Added Prettier scoped to Markdown/MDX files only. Configured VS Code format-on-save integration.
+
+## 2026-02-06
+
+### docs(djf.io): audit blog migration progress
+
+Audited djf.io against migration plan. Phases 1-5 and 7 confirmed complete. Updated plan.md to reflect actual state. Remaining: search (Pagefind), testing (Vitest/Playwright), polish (SEO/OG/sitemap).

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -1,0 +1,36 @@
+# Changelog
+
+Change history for the monorepo, organized as monthly files in reverse chronological order.
+
+## Format
+
+Each file is named `YYYY-MM.md` and contains entries grouped by date. Entries use [conventional commit](https://www.conventionalcommits.org/) categories.
+
+```markdown
+## YYYY-MM-DD
+
+### type(scope): short description
+
+Context about what changed and why.
+```
+
+### Types
+
+- `feat` -- new feature or capability
+- `fix` -- bug fix
+- `refactor` -- code restructuring without behavior change
+- `docs` -- documentation only
+- `chore` -- tooling, config, dependencies
+- `test` -- adding or updating tests
+
+### Scopes
+
+Use the app or area name: `djf.io`, `calendar-visualizer`, `ravrun`, `tooling`, `docs`, `repo`.
+
+## Per-app changelogs
+
+Published packages may maintain their own `CHANGELOG.md` at `apps/<name>/CHANGELOG.md` for release-specific history. This directory captures repo-wide changes across all apps and infrastructure.
+
+## Files
+
+- [2026-02.md](./2026-02.md)

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -15,3 +15,9 @@ Migrating djf.io from Starlight to a custom Astro + MDX + PandaCSS setup for gre
 Consolidating dev tooling to root-level mise config. Upgrading Biome (2.0 -> 2.4), Oxlint (0.16 -> 1.x), adding Prettier for Markdown/MDX.
 
 **Status**: In Progress
+
+### [Contribution Docs](./projects/contribution-docs/plan.md)
+
+Adding contribution guidelines, changelog structure, and PR template. Primary audience is AI agents.
+
+**Status**: In Progress

--- a/docs/projects/contribution-docs/2026-02-24-progress.md
+++ b/docs/projects/contribution-docs/2026-02-24-progress.md
@@ -1,0 +1,27 @@
+# 2026-02-24
+
+## Summary
+
+Initial implementation of contribution docs, changelog structure, and PR template.
+
+## Work completed
+
+- Created `CONTRIBUTING.md` with agent-focused contribution guidelines
+- Created `AGENTS.md` as universal AI agent entry point
+- Updated `CLAUDE.md` with cross-references to new docs
+- Created `docs/changelog/` structure with monthly date-partitioned files
+- Seeded `docs/changelog/2026-02.md` with entries for recent work
+- Created `.github/PULL_REQUEST_TEMPLATE.md` enforcing conventional commits
+
+## Decisions made
+
+- Use both AGENTS.md and CLAUDE.md for maximum AI tool coverage
+- Monthly changelog files instead of changesets (better fit for mixed published/deployed apps)
+- Conventional commit format for PR titles (squash merge produces clean history)
+- No emojis in any documentation
+
+## Next steps
+
+- Monitor whether monthly granularity is appropriate or needs adjustment
+- Add per-app AGENTS.md files as apps grow in complexity
+- Consider per-app CHANGELOG.md for published packages when publishing begins

--- a/docs/projects/contribution-docs/plan.md
+++ b/docs/projects/contribution-docs/plan.md
@@ -1,0 +1,39 @@
+# Contribution Docs
+
+## Goal
+
+Establish lightweight contribution guidelines, changelog tracking, and PR templates for the monorepo. Primary audience is AI agents (Claude Code, GitHub Copilot) that operate on this repo.
+
+## Rationale
+
+- No CONTRIBUTING.md, AGENTS.md, or PR template exists
+- No changelog or change tracking beyond project progress files
+- Multiple AI tools interact with the repo via GitHub Actions and need clear conventions
+
+## Implementation
+
+### Phase 1: Documentation scaffolding
+
+- Create `CONTRIBUTING.md` at root (short, references other files)
+- Create `AGENTS.md` at root (universal AI agent entry point)
+- Update `CLAUDE.md` with cross-references
+
+### Phase 2: Changelog structure
+
+- Create `docs/changelog/` with monthly date-partitioned files
+- Seed with entries for recent work
+- Document the format in `docs/changelog/README.md`
+
+### Phase 3: PR template
+
+- Create `.github/PULL_REQUEST_TEMPLATE.md`
+- Enforce conventional commit titles
+- Structured body with summary, changes, changelog entry, testing
+
+## Relevant files
+
+- [CLAUDE.md](/CLAUDE.md)
+- [CONTRIBUTING.md](/CONTRIBUTING.md)
+- [AGENTS.md](/AGENTS.md)
+- [PR template](/.github/PULL_REQUEST_TEMPLATE.md)
+- [Changelog format](/docs/changelog/README.md)


### PR DESCRIPTION
## Summary

Establish lightweight contribution guidelines, changelog tracking, and PR templates for the monorepo. These docs are primarily targeted at AI agents (Claude Code, GitHub Copilot) but also serve human contributors.

## Key changes

- **CONTRIBUTING.md** – New root-level guide covering PR workflow, conventional commit format, code/documentation conventions, and references to related docs
- **AGENTS.md** – New universal entry point for AI agents with repository overview, key paths, conventions, and cross-references
- **PR template** – New `.github/PULL_REQUEST_TEMPLATE.md` enforcing conventional commit titles and structured body with summary, changes, changelog entry, and testing checklist
- **Changelog structure** – New `docs/changelog/` directory with monthly date-partitioned files (`YYYY-MM.md`) and format documentation in `docs/changelog/README.md`
- **Seeded changelog** – Initial entries in `docs/changelog/2026-02.md` for recent work (contribution docs, tooling consolidation, djf.io audit)
- **Updated CLAUDE.md** – Added "Related Docs" section with cross-references to new contribution and agent docs
- **Updated docs/projects.md** – Added "Contribution Docs" project entry with link to plan

## Implementation details

- Conventional commit format (`type(scope): description`) enforced for PR titles with defined types (feat, fix, refactor, docs, chore, test) and scopes (djf.io, calendar-visualizer, ravrun, tooling, docs, repo)
- Monthly changelog files instead of changesets for better fit with mixed published/deployed apps
- No emojis in any documentation per project conventions
- Project plan documented in `docs/projects/contribution-docs/plan.md` with three phases (documentation scaffolding, changelog structure, PR template)

https://claude.ai/code/session_01VNQ36SNEVGSRxYotFWNTuZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that don’t affect runtime code paths or data handling; risk is limited to minor process friction if conventions don’t match existing workflows.
> 
> **Overview**
> Introduces repo-wide contribution/process scaffolding: a new `.github/PULL_REQUEST_TEMPLATE.md` that enforces `type(scope): description` titles and standard sections (summary/changes/changelog/testing), plus new root `CONTRIBUTING.md` and `AGENTS.md` to document PR workflow and conventions for AI agents.
> 
> Adds a new `docs/changelog/` structure with a documented format (`docs/changelog/README.md`) and an initial monthly file (`2026-02.md`) seeded with recent entries, and wires the effort into docs by adding a “Related Docs” section in `CLAUDE.md`, a new `docs/projects/contribution-docs/` plan+progress, and an entry in `docs/projects.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 856b04e1366d8ef7faa6745a024f312f1e19a48a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->