### PR TITLE
docs(repo): add linter standardization and ghalint projects

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -75,3 +75,15 @@ Refresh the GitHub profile bio in `README.md`.
 Wire PostHog into every app in the repo for product analytics.
 
 **Status**: In Progress
+
+### [ghalint & pinact](./projects/ghalint-pinact/plan.md)
+
+Adopt ghalint and pinact to lint GitHub Actions workflows and pin action references to immutable commit SHAs.
+
+**Status**: In Progress
+
+### [Linter & Formatter Standardization](./projects/linter-formatter-standardization/plan.md)
+
+Converge on a single, consistent set of linters and formatters across the entire monorepo with clear tool-to-file-type ownership.
+
+**Status**: In Progress

--- a/docs/projects/ghalint-pinact/2026-04-29-progress.md
+++ b/docs/projects/ghalint-pinact/2026-04-29-progress.md
@@ -1,0 +1,15 @@
+# 2026-04-29 Progress
+
+## Summary
+
+Project created. Plan written for adopting ghalint and pinact to lint and pin GitHub Actions.
+
+## Work Completed
+
+- Created project plan with three phases: install via mise, fix existing workflows, CI enforcement
+
+## Next Steps
+
+- Add ghalint and pinact to `.config/mise.toml`
+- Run both tools against existing workflows and fix issues
+- Add CI enforcement step

--- a/docs/projects/ghalint-pinact/plan.md
+++ b/docs/projects/ghalint-pinact/plan.md
@@ -1,0 +1,33 @@
+# Add ghalint & pinact
+
+## Goal
+
+Adopt [ghalint](https://github.com/suzuki-shunsuke/ghalint) and [pinact](https://github.com/suzuki-shunsuke/pinact) to lint and pin GitHub Actions across the repo.
+
+## Rationale
+
+- **ghalint** catches common GitHub Actions anti-patterns (missing permissions, unpinned actions, deprecated syntax)
+- **pinact** rewrites action references from mutable tags to immutable full-length commit SHAs, preventing supply-chain attacks via tag re-pointing
+- Together they enforce a security-first, lint-clean CI configuration
+
+## Implementation
+
+### Phase 1: Install via mise
+
+- Add `ghalint` and `pinact` to `.config/mise.toml`
+- Verify both tools run against existing workflows
+
+### Phase 2: Fix existing workflows
+
+- Run `pinact run` to pin all action references to SHAs
+- Run `ghalint run` and fix any reported issues
+- Commit fixes
+
+### Phase 3: CI enforcement
+
+- Add a CI step (or pre-commit hook) that runs `ghalint run` and `pinact run --verify` so unpinned or non-compliant actions fail the build
+
+## Files
+
+- `.config/mise.toml` - tool versions
+- `.github/workflows/*.yml` - all workflow files

--- a/docs/projects/linter-formatter-standardization/2026-04-29-progress.md
+++ b/docs/projects/linter-formatter-standardization/2026-04-29-progress.md
@@ -1,0 +1,16 @@
+# 2026-04-29 Progress
+
+## Summary
+
+Project created. Plan written for standardizing linters and formatters across the monorepo.
+
+## Work Completed
+
+- Created project plan with four phases: audit, define standard, migrate configs, CI/editor integration
+- Linked to related dev-tooling-consolidation and ghalint-pinact projects
+
+## Next Steps
+
+- Audit all existing lint/format configs across apps
+- Draft the canonical tool-to-file-type ownership map
+- Begin removing redundant or conflicting configs

--- a/docs/projects/linter-formatter-standardization/plan.md
+++ b/docs/projects/linter-formatter-standardization/plan.md
@@ -1,0 +1,52 @@
+# Standardize on Linters and Formatters
+
+## Goal
+
+Converge on a single, consistent set of linters and formatters across the entire monorepo so every app follows the same rules and there is no ambiguity about which tool owns which file type.
+
+## Rationale
+
+- Multiple apps currently have overlapping or inconsistent lint/format configs
+- Developers (human and AI) shouldn't have to guess which tool to run
+- A clear ownership map reduces CI complexity and eliminates conflicting fixes
+- Builds on [Dev Tooling Consolidation](../dev-tooling-consolidation/plan.md) which hoists tools into mise; this project defines the authoritative ruleset
+
+## Implementation
+
+### Phase 1: Audit current state
+
+- Inventory every lint/format config across apps (Biome, Oxlint, ESLint, Prettier, cspell, editorconfig)
+- Document which tool currently owns each file type and where configs conflict
+
+### Phase 2: Define the standard
+
+- Decide the canonical tool for each file type:
+  - JS/TS/JSX/TSX: Biome (lint + format)
+  - JSON/JSONC: Biome (format)
+  - CSS: Biome (lint + format)
+  - Astro/Vue/Svelte: Biome (lint + format, with framework plugins)
+  - Markdown/MDX: Prettier (format only)
+  - Spell check: cspell
+  - GitHub Actions: ghalint (see [ghalint-pinact](../ghalint-pinact/plan.md))
+- Document the standard in a short reference (e.g. `docs/tooling-standard.md` or in CLAUDE.md)
+
+### Phase 3: Migrate configs
+
+- Remove any remaining ESLint configs
+- Unify Biome and Oxlint rule sets across apps (single root config, app-level overrides only when necessary)
+- Ensure Prettier is scoped strictly to Markdown/MDX
+
+### Phase 4: CI and editor integration
+
+- Single CI job that runs the full lint + format suite
+- VS Code / editor settings that match the standard (format-on-save, correct formatter per language)
+
+## Files
+
+- `biome.jsonc` - root Biome config
+- `.oxlintrc.json` - root Oxlint config
+- `.prettierrc.json` / `.prettierignore` - Prettier (MD/MDX only)
+- `.config/cspell.json` - spell check dictionary
+- `.vscode/settings.json` - editor integration
+- `apps/*/biome.jsonc` - per-app overrides (if any)
+- `apps/*/.eslintrc*` - to be removed


### PR DESCRIPTION
## Summary

Add two new project plans to the monorepo: one for standardizing linters and formatters across all apps, and another for adopting ghalint and pinact to lint and pin GitHub Actions workflows.

## Changes

- Created `docs/projects/linter-formatter-standardization/plan.md` with a four-phase plan to converge on Biome for JS/TS/CSS/Astro/Vue/Svelte, Prettier for Markdown/MDX, and cspell for spell-checking
- Created `docs/projects/linter-formatter-standardization/2026-04-29-progress.md` with initial project status
- Created `docs/projects/ghalint-pinact/plan.md` with a three-phase plan to adopt ghalint and pinact for GitHub Actions linting and SHA pinning
- Created `docs/projects/ghalint-pinact/2026-04-29-progress.md` with initial project status
- Updated `docs/projects.md` to list both new projects with their status

## Changelog entry

```markdown
### docs(repo): add linter standardization and ghalint projects

Added project plans for standardizing linters/formatters across the monorepo and adopting ghalint/pinact for GitHub Actions security and compliance.
```

## Testing

- [x] Documentation files are well-formed and follow existing project structure
- [x] Links to related projects are correct
- [x] Projects are properly indexed in `docs/projects.md`

https://claude.ai/code/session_018Zp2yo582U8aQW241XFnuD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit be6b9988deaccfb392e9a9b858f65b414eba6c02. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->