### PR TITLE
feat(cloudflare): deploy calendar-visualizer and djf.io via Workers

### DIFF
--- a/.github/workflows/calendar-visualizer-deploy.yml
+++ b/.github/workflows/calendar-visualizer-deploy.yml
@@ -1,0 +1,41 @@
+name: calendar-visualizer deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/calendar-visualizer/**'
+      - '.github/workflows/calendar-visualizer-deploy.yml'
+
+defaults:
+  run:
+    working-directory: apps/calendar-visualizer
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Workers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+        with:
+          install: true
+          cache: true
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: apps/calendar-visualizer

--- a/.github/workflows/djf-io-deploy.yml
+++ b/.github/workflows/djf-io-deploy.yml
@@ -1,0 +1,41 @@
+name: djf.io deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/djf.io/**'
+      - '.github/workflows/djf-io-deploy.yml'
+
+defaults:
+  run:
+    working-directory: apps/djf.io
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Workers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+        with:
+          install: true
+          cache: true
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: apps/djf.io

--- a/apps/calendar-visualizer/wrangler.toml
+++ b/apps/calendar-visualizer/wrangler.toml
@@ -1,0 +1,6 @@
+#:schema node_modules/wrangler/config-schema.json
+name = "calendar-visualizer"
+compatibility_date = "2026-04-29"
+
+[assets]
+directory = "./dist"

--- a/apps/djf.io/wrangler.toml
+++ b/apps/djf.io/wrangler.toml
@@ -1,0 +1,6 @@
+#:schema node_modules/wrangler/config-schema.json
+name = "djf-io"
+compatibility_date = "2026-04-29"
+
+[assets]
+directory = "./dist"

--- a/docs/projects/cloudflare-migration/2026-04-30-progress.md
+++ b/docs/projects/cloudflare-migration/2026-04-30-progress.md
@@ -1,0 +1,32 @@
+# 2026-04-30 — calendar-visualizer & djf.io migration
+
+## Summary
+
+Added Cloudflare Workers config and deploy workflows for the remaining two apps.
+
+## Work completed
+
+- Created `wrangler.toml` for calendar-visualizer (Workers Static Assets, `dist/` output)
+- Created `wrangler.toml` for djf.io (Workers Static Assets, `dist/` output)
+- Created `.github/workflows/calendar-visualizer-deploy.yml` (path-scoped, same pattern as ravrun)
+- Created `.github/workflows/djf-io-deploy.yml` (path-scoped, same pattern as ravrun)
+- Verified both apps build successfully and produce `dist/` output
+- Updated plan status for all three apps
+
+## Decisions
+
+- Both calendar-visualizer and djf.io are static Astro builds — no SSR adapter needed, same Workers Static Assets approach as ravrun
+- djf.io Worker named `djf-io` (dots not allowed in Worker names)
+
+## Human tasks remaining (all apps)
+
+1. Add GitHub repo secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
+2. Add custom domain routes in Cloudflare dashboard for each Worker
+3. Merge and verify deploy Actions succeed
+4. Tear down Vercel projects once Cloudflare is confirmed working
+
+## Next steps
+
+- Merge this branch
+- Verify all three deploy workflows run successfully
+- Set up custom domains and tear down Vercel

--- a/docs/projects/cloudflare-migration/plan.md
+++ b/docs/projects/cloudflare-migration/plan.md
@@ -14,9 +14,9 @@ Migrate all Vercel-hosted projects to Cloudflare Pages, deploying via GitHub Act
 
 | App | Type | Status |
 |-----|------|--------|
-| `apps/ravrun` | Static SPA (Vite + React) | In progress |
-| `apps/calendar-visualizer` | TBD | Not started |
-| `apps/djf.io` | Astro SSR/SSG | Not started |
+| `apps/ravrun` | Static SPA (Vite + React) | Done (pending secrets + domain) |
+| `apps/calendar-visualizer` | Static (Astro + React) | Done (pending secrets + domain) |
+| `apps/djf.io` | Static (Astro + MDX + React) | Done (pending secrets + domain) |
 
 ## Migration Playbook (per app)
 


### PR DESCRIPTION
## Summary

- Add Cloudflare Workers Static Assets config (`wrangler.toml`) for calendar-visualizer and djf.io
- Add GitHub Actions deploy workflows for both apps (path-scoped, deploy on push to main)
- Same pattern as the ravrun migration from #85 — completes the Cloudflare migration for all apps

## After merge

1. Custom domain routes need to be set in Cloudflare dashboard for each Worker
2. Verify deploys succeed on first push
3. Tear down the Vercel projects once confirmed

## Test plan

- [x] Both apps build successfully locally with `dist/` output
- [ ] Deploy workflows trigger and succeed after merge
- [ ] Sites are reachable on Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new CI/CD deployment workflows and Cloudflare `wrangler.toml` configs for two apps; mistakes could cause failed or unintended production deployments but changes are isolated to build/deploy configuration.
> 
> **Overview**
> Adds Cloudflare Workers Static Assets deployment for `apps/calendar-visualizer` and `apps/djf.io`.
> 
> Creates path-scoped GitHub Actions workflows that run `pnpm build` and `wrangler deploy` on pushes to `main` for each app, and adds app-local `wrangler.toml` files pointing Workers assets to `./dist` (with `djf.io` deployed under the Worker name `djf-io`).
> 
> Updates Cloudflare migration docs with a progress entry and marks all apps as done pending secrets and domain setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b3147f02aa64789ae9f07e64593fae304dc8773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->