### PR TITLE
docs(projects): add hermes, openclaw, warp, astro upgrade plans

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -87,3 +87,33 @@ Adopt ghalint and pinact to lint GitHub Actions workflows and pin action referen
 Converge on a single, consistent set of linters and formatters across the entire monorepo with clear tool-to-file-type ownership.
 
 **Status**: In Progress
+
+### [Setup Hermes](./projects/setup-hermes/plan.md)
+
+Set up Hermes.
+
+**Status**: In Progress
+
+### [Setup OpenClaw](./projects/setup-openclaw/plan.md)
+
+Set up OpenClaw.
+
+**Status**: In Progress
+
+### [Upgrade Astro Versions](./projects/upgrade-astro-versions/plan.md)
+
+Upgrade djf.io from Astro 5 to Astro 6.
+
+**Status**: In Progress
+
+### [Setup Warp](./projects/setup-warp/plan.md)
+
+Install the Warp CLI and explore using it.
+
+**Status**: In Progress
+
+### [Update Warp Config](./projects/update-warp-config/plan.md)
+
+Pull configuration items from dotfiles into Warp and sync Warp-native config back into the repo.
+
+**Status**: In Progress

--- a/docs/projects/setup-hermes/2026-04-30-progress.md
+++ b/docs/projects/setup-hermes/2026-04-30-progress.md
@@ -1,0 +1,19 @@
+# 2026-04-30 — Project kickoff
+
+Created project. Most of the work is research + a one-time setup, not ongoing.
+
+## Scope clarified
+
+- Figure out where to host Hermes.
+- Use Tailscale for secure access from anywhere.
+- Investigate API/model providers and gateways: Daytona, Cloudflare AI Gateway, OpenRouter, Vercel Sandboxes, direct provider APIs.
+
+## Next
+
+- Begin research phase: hosting options, Tailscale integration patterns, provider landscape.
+- Capture findings in a follow-up progress note before making decisions.
+
+## Open questions
+
+- What does Hermes' runtime actually need (long-running process? persistent storage? GPU?) — answers gate hosting choice.
+- Is sandboxed code execution required day one, or can it come later? Drives whether Daytona/Vercel Sandboxes are in scope now.

--- a/docs/projects/setup-hermes/plan.md
+++ b/docs/projects/setup-hermes/plan.md
@@ -1,0 +1,47 @@
+# Setup Hermes
+
+## Goal
+
+Get Hermes running somewhere it can be accessed securely from anywhere, backed by sensible API/provider choices for model access. Most of the work is research and decision-making, then a one-time setup.
+
+## Open Questions
+
+### Hosting
+
+Where should Hermes run? Options to evaluate:
+
+- Self-hosted on a home server / NAS
+- VPS (Hetzner, Fly.io, Railway, etc.)
+- Cloudflare (Workers / Containers)
+- Vercel
+- A dedicated cloud VM
+
+Decision criteria: cost, latency, persistence needs, runtime fit (long-running vs. request/response), ease of updates.
+
+### Access
+
+Use Tailscale for secure remote access. Decide:
+
+- Tailscale on the host directly vs. a sidecar/subnet router
+- Whether to expose via Tailscale Funnel/Serve or keep tailnet-only
+- ACLs and tagging
+- MagicDNS hostname
+
+### API / Model Providers
+
+Investigate which providers (and gateways) to wire up:
+
+- [Daytona](https://daytona.io) — sandboxes for code execution
+- Cloudflare AI Gateway — caching, rate limiting, observability
+- OpenRouter — multi-model routing
+- Vercel Sandboxes
+- Direct provider APIs (Anthropic, OpenAI, etc.)
+
+Decision criteria: which combination gives the best mix of model coverage, sandboxed code execution, observability, and cost control. Likely some combination, not just one.
+
+## Phases
+
+1. **Research** — survey hosting, Tailscale integration patterns, and provider/gateway landscape; capture findings in progress notes.
+2. **Decide** — pick hosting + access pattern + provider stack.
+3. **Set up** — provision host, install Hermes, wire Tailscale, configure providers, smoke test from a remote device.
+4. **Document** — write down the resulting setup so it's reproducible.

--- a/docs/projects/setup-openclaw/2026-04-30-progress.md
+++ b/docs/projects/setup-openclaw/2026-04-30-progress.md
@@ -1,0 +1,21 @@
+# 2026-04-30 — Project kickoff
+
+Created project. Most of the work is research + a one-time setup, not ongoing. Scope mirrors [Setup Hermes](../setup-hermes/plan.md).
+
+## Scope clarified
+
+- Figure out where to host OpenClaw.
+- Use Tailscale for secure access from anywhere.
+- Investigate API/model providers and gateways: Daytona, Cloudflare AI Gateway, OpenRouter, Vercel Sandboxes, direct provider APIs.
+- Reuse decisions/accounts from Hermes wherever they overlap.
+
+## Next
+
+- Begin research phase alongside Hermes; treat them as a single research effort with two installs.
+- Capture findings in a follow-up progress note before making decisions.
+
+## Open questions
+
+- What does OpenClaw's runtime need (long-running process? persistent storage? GPU?) — answers gate hosting choice.
+- Same host as Hermes, or separate? Trade-off: simpler ops vs. blast-radius isolation.
+- Is sandboxed code execution required day one, or can it come later?

--- a/docs/projects/setup-openclaw/plan.md
+++ b/docs/projects/setup-openclaw/plan.md
@@ -1,0 +1,51 @@
+# Setup OpenClaw
+
+## Goal
+
+Get OpenClaw running somewhere it can be accessed securely from anywhere, backed by sensible API/provider choices for model access. Most of the work is research and decision-making, then a one-time setup.
+
+## Open Questions
+
+### Hosting
+
+Where should OpenClaw run? Options to evaluate:
+
+- Self-hosted on a home server / NAS
+- VPS (Hetzner, Fly.io, Railway, etc.)
+- Cloudflare (Workers / Containers)
+- Vercel
+- A dedicated cloud VM
+
+Decision criteria: cost, latency, persistence needs, runtime fit (long-running vs. request/response), ease of updates.
+
+### Access
+
+Use Tailscale for secure remote access. Decide:
+
+- Tailscale on the host directly vs. a sidecar/subnet router
+- Whether to expose via Tailscale Funnel/Serve or keep tailnet-only
+- ACLs and tagging
+- MagicDNS hostname
+
+### API / Model Providers
+
+Investigate which providers (and gateways) to wire up:
+
+- [Daytona](https://daytona.io) — sandboxes for code execution
+- Cloudflare AI Gateway — caching, rate limiting, observability
+- OpenRouter — multi-model routing
+- Vercel Sandboxes
+- Direct provider APIs (Anthropic, OpenAI, etc.)
+
+Decision criteria: which combination gives the best mix of model coverage, sandboxed code execution, observability, and cost control. Likely some combination, not just one.
+
+## Coordination with Hermes
+
+This project mirrors [Setup Hermes](../setup-hermes/plan.md). Share decisions where it makes sense — hosting account/VPS, Tailscale tailnet/ACLs, AI gateway and provider accounts can likely be reused rather than duplicated. Diverge only where OpenClaw's runtime needs differ.
+
+## Phases
+
+1. **Research** — survey hosting, Tailscale integration patterns, and provider/gateway landscape; capture findings in progress notes (cross-reference Hermes findings).
+2. **Decide** — pick hosting + access pattern + provider stack.
+3. **Set up** — provision host, install OpenClaw, wire Tailscale, configure providers, smoke test from a remote device.
+4. **Document** — write down the resulting setup so it's reproducible.

--- a/docs/projects/setup-warp/2026-04-30-progress.md
+++ b/docs/projects/setup-warp/2026-04-30-progress.md
@@ -1,0 +1,8 @@
+# 2026-04-30 — Project kickoff
+
+Created project. Scope narrowed: install the Warp CLI and explore using it. Config migration split into its own project — see [Update Warp Config](../update-warp-config/plan.md).
+
+## Next
+
+- Install the Warp CLI.
+- Spend time exploring features and workflows.

--- a/docs/projects/setup-warp/plan.md
+++ b/docs/projects/setup-warp/plan.md
@@ -1,0 +1,15 @@
+# Setup Warp
+
+## Goal
+
+Install the Warp CLI and spend time exploring how to use it.
+
+## Scope
+
+- Download and install the Warp CLI.
+- Learn the workflows: agents, blocks, sessions, AI features, command palette.
+- Identify which features are worth integrating into day-to-day usage.
+
+## Out of scope
+
+- Updating configuration. Config work — pulling items from dotfiles and migrating them into Warp — is tracked separately under [Update Warp Config](../update-warp-config/plan.md).

--- a/docs/projects/update-warp-config/2026-04-30-progress.md
+++ b/docs/projects/update-warp-config/2026-04-30-progress.md
@@ -1,0 +1,13 @@
+# 2026-04-30 — Project kickoff
+
+Split out from [Setup Warp](../setup-warp/plan.md). That project covers install + exploration; this one covers config migration.
+
+## Scope clarified
+
+- Pull configuration items from dotfiles into Warp.
+- Sync Warp-native config back into the dotfiles repo.
+
+## Next
+
+- Wait for Setup Warp to land (CLI installed, baseline exploration done).
+- Then inventory dotfiles config items that need to flow into Warp.

--- a/docs/projects/update-warp-config/plan.md
+++ b/docs/projects/update-warp-config/plan.md
@@ -1,0 +1,17 @@
+# Update Warp Config
+
+## Goal
+
+Bring Warp's configuration in line with the rest of the dev environment by pulling configuration items from dotfiles and updating them.
+
+## Scope
+
+- Inventory existing dotfiles config that should also apply to Warp (shell init, prompt, aliases, env vars, keybindings, themes).
+- Decide what belongs in Warp-native config (workflows, launch configs, themes, AI rules) vs. what should stay in shared shell dotfiles.
+- Migrate the relevant items into Warp's config and verify they work.
+- Sync Warp-native config back into the dotfiles repo so it's version-controlled.
+
+## Dependencies
+
+- [Setup Warp](../setup-warp/plan.md) — CLI installed and basic exploration done first.
+- [Dotfiles Overhaul](../dotfiles-overhaul/plan.md) — coordinate with shell migration (omz → fish), starship, nushell so Warp picks up the right shell setup.

--- a/docs/projects/upgrade-astro-versions/2026-04-30-progress.md
+++ b/docs/projects/upgrade-astro-versions/2026-04-30-progress.md
@@ -1,0 +1,14 @@
+# 2026-04-30 — Project kickoff
+
+Created project. Scope is narrower than the name suggests: only djf.io needs upgrading.
+
+## Scope clarified
+
+- djf.io is currently on `astro@^5.18.1` ([apps/djf.io/package.json](../../../apps/djf.io/package.json)).
+- Target: Astro 6.
+- Bump official `@astrojs/*` integrations alongside.
+
+## Next
+
+- Read the Astro 5 → 6 migration guide.
+- Bump versions and work through any breakage.

--- a/docs/projects/upgrade-astro-versions/plan.md
+++ b/docs/projects/upgrade-astro-versions/plan.md
@@ -1,0 +1,24 @@
+# Upgrade Astro Versions
+
+## Goal
+
+Upgrade [djf.io](../../../apps/djf.io) from Astro 5 to Astro 6.
+
+## Scope
+
+- Bump `astro` from `^5.18.1` to the latest 6.x in [apps/djf.io/package.json](../../../apps/djf.io/package.json).
+- Bump official integrations as needed for Astro 6 compatibility: `@astrojs/mdx`, `@astrojs/react`, `@astrojs/rss`, `@astrojs/check`.
+- Address any breaking changes from the Astro 5 → 6 migration guide.
+- Verify build, tests (Vitest + Playwright), and Cloudflare Workers deploy still pass.
+
+## Out of scope
+
+- Other apps in the repo (only djf.io is on Astro today).
+- Non-Astro dependency upgrades — handled separately under [Dependency Freshness](../dependency-freshness/plan.md).
+
+## Phases
+
+1. **Read the migration guide** and note any breaking changes that touch this codebase.
+2. **Bump versions** and run `pnpm install`.
+3. **Fix breakage** until typecheck, lint, build, and tests pass locally.
+4. **Verify deploy** to Cloudflare Workers preview before merging.


### PR DESCRIPTION
## Summary

Adds five new project docs under \`docs/projects/\` and indexes them in \`docs/projects.md\`:

- **setup-hermes** — research hosting, Tailscale-based remote access, and provider/gateway stack (Daytona, Cloudflare AI Gateway, OpenRouter, Vercel Sandboxes, direct APIs).
- **setup-openclaw** — same shape as Hermes; calls out shared accounts/tailnet/gateway with Hermes where it makes sense.
- **setup-warp** — install the Warp CLI and explore.
- **update-warp-config** — split out from setup-warp; pull config from dotfiles into Warp and sync Warp-native config back. Depends on setup-warp and dotfiles-overhaul.
- **upgrade-astro-versions** — scoped to bumping djf.io from Astro 5 to Astro 6, plus \`@astrojs/*\` integrations.

Each project has a \`plan.md\` and a \`2026-04-30-progress.md\` kickoff note, per the conventions in CLAUDE.md.

## Why

Capturing planned work up front so it's tracked alongside the other active projects rather than living only in chat.

## Test plan

- [ ] Skim each plan.md for accuracy
- [ ] Confirm projects.md links resolve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds planning notes and index links; no runtime or configuration behavior is modified.
> 
> **Overview**
> Adds **five new project entries** to `docs/projects.md` and introduces their initial documentation under `docs/projects/`.
> 
> Each new project includes a `plan.md` and a kickoff `2026-04-30-progress.md`, covering: setting up *Hermes* and *OpenClaw* (hosting + Tailscale access + model provider/gateway research), splitting *Warp* into install/exploration vs. config-migration work, and planning an *Astro 5 → 6* upgrade scoped to `djf.io`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5ce54913fd631f3a60622a31c48a3d1e24df10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->