### PR TITLE
docs(repo): add pending issues and reading list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,19 @@ Each progress file should contain:
 - Next steps
 - Any blockers or open questions
 
+## Human Intervention Tasks
+
+When a task can't be completed by the agent — it requires David's hands on a local machine, a credential, a third-party account decision, a DNS change, a physical device, etc. — do not bury it in a progress note. Open a GitHub issue and assign it to `@DavidJFelix`.
+
+Each such issue MUST contain:
+
+- **Background** — 1-3 sentences on why this needs a human, and why now.
+- **Steps** — a markdown checklist (`- [ ]`) of concrete actions. One verb per step. Each step independently checkable.
+- **Automation follow-up** — how we avoid doing this manually next time (a tool to install, a script to write, a config to commit, a follow-up issue to file). If it's genuinely one-shot, say so.
+- **Related** — links to the project plan, progress note, PR, or other issue this connects to.
+
+Keep it short. The issue body should fit on one screen. If it doesn't fit, the task is probably two tasks.
+
 ## Related Docs
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) -- PR workflow, changelog process, code conventions

--- a/docs/pending-issues.md
+++ b/docs/pending-issues.md
@@ -1,0 +1,121 @@
+# Pending GitHub Issues
+
+Drafts of GitHub issues that need to be filed against `DavidJFelix/DavidJFelix` and assigned to `@DavidJFelix`. The GitHub MCP server was disconnected when these were drafted; cut them via MCP when it's back, then delete this file.
+
+Format follows the [Human Intervention Tasks](../CLAUDE.md#human-intervention-tasks) section of `CLAUDE.md`.
+
+---
+
+## Issue: Install the Warp CLI on local machine
+
+**Assignee:** @DavidJFelix
+**Labels:** human-intervention, setup-warp
+
+### Background
+
+The `setup-warp` project is gated on the Warp CLI being installed locally. The agent can't install a desktop terminal app for you. Once installed, exploration of features (agents, blocks, sessions, AI, command palette) can proceed.
+
+### Steps
+
+- [ ] Download the Warp CLI from https://www.warp.dev/
+- [ ] Install it via the platform-appropriate method (Homebrew cask, official installer, etc.)
+- [ ] Verify the install: run `warp --version` in a terminal
+- [ ] Launch Warp once to complete first-run setup (auth, telemetry choice)
+- [ ] Comment on this issue with the install method used, so it can be captured in `dotfiles/Brewfile` or equivalent
+
+### Automation follow-up
+
+Once we know which install method we're standardizing on, add it to `dotfiles/Brewfile` (or the equivalent package list) so it's reproducible across machines. Track that work under [Update Warp Config](docs/projects/update-warp-config/plan.md).
+
+### Related
+
+- [Setup Warp](docs/projects/setup-warp/plan.md)
+- [Update Warp Config](docs/projects/update-warp-config/plan.md) (blocked on this)
+
+---
+
+## Issue: Create Sentry org and per-app projects
+
+**Assignee:** @DavidJFelix
+**Labels:** human-intervention, sentry-integration
+
+### Background
+
+The `sentry-integration` project can't ship a pattern until there's a Sentry org and at least one project to point at. Account creation, billing, and org/project structure require your login — the agent can't do this. Picking the layout now (one project per app vs. one project with environments) blocks the rollout pattern for every other app.
+
+### Steps
+
+- [ ] Sign in / sign up at https://sentry.io
+- [ ] Create or confirm the org (e.g. `davidjfelix`)
+- [ ] Decide the project layout: one Sentry project per app, or one project with environments per app. Note the decision in `docs/projects/sentry-integration/`.
+- [ ] Create the first project for `djf.io` as the pilot
+- [ ] Copy the DSN into a password manager entry (do NOT paste it here)
+- [ ] Comment on this issue with: org slug, project slug, and confirmation the DSN is stashed
+
+### Automation follow-up
+
+Once the pilot pattern is proven on djf.io, the per-app wire-up (SDK install, source map upload, release tagging in CI) can be scripted into a reusable skill so additional apps go in with one command. File that as a follow-up under `sentry-integration`.
+
+### Related
+
+- [Sentry Integration](docs/projects/sentry-integration/plan.md)
+- Parallel: [PostHog Integration](docs/projects/posthog-integration/plan.md)
+
+---
+
+## Issue: Create PostHog org and per-app projects
+
+**Assignee:** @DavidJFelix
+**Labels:** human-intervention, posthog-integration
+
+### Background
+
+Same shape as the Sentry task: the `posthog-integration` rollout can't pick a per-app pattern until there's a PostHog org/project to wire into. Account creation and project layout decisions need your login.
+
+### Steps
+
+- [ ] Sign in / sign up at https://posthog.com (or self-host — note the choice)
+- [ ] Create or confirm the org
+- [ ] Decide layout: one project per app, or one project with `app` as a property. Note the decision in `docs/projects/posthog-integration/`.
+- [ ] Create the first project for `djf.io` as the pilot
+- [ ] Copy the project API key into a password manager entry
+- [ ] Comment on this issue with: org slug, project slug, hosting choice (cloud vs. self-host)
+
+### Automation follow-up
+
+After the djf.io pilot, the per-app wire-up (SDK install, identify/capture conventions, autocapture toggles) becomes a reusable skill. File that as a follow-up.
+
+### Related
+
+- [PostHog Integration](docs/projects/posthog-integration/plan.md)
+- Parallel: [Sentry Integration](docs/projects/sentry-integration/plan.md)
+
+---
+
+## Issue: DNS cutover for davidjfelix.com
+
+**Assignee:** @DavidJFelix
+**Labels:** human-intervention, new-domain-sites
+
+### Background
+
+`apps/davidjfelix.com/` is scaffolded and the Cloudflare Workers deploy workflow is in place, but `wrangler.toml` is intentionally missing the `routes` entry because the domain isn't pointed at the Worker yet. DNS records live in Cloudflare and changing them requires your login. Without this, the site is deployed but unreachable at the apex domain.
+
+### Steps
+
+- [ ] Log into Cloudflare → `davidjfelix.com` zone
+- [ ] Confirm the Worker for `davidjfelix-com` is deployed and reachable at its `*.workers.dev` URL
+- [ ] In the Worker → Settings → Triggers (or via wrangler), attach `davidjfelix.com` and `www.davidjfelix.com` as custom domains
+- [ ] Verify DNS resolves and HTTPS serves the site from the apex
+- [ ] Add the `routes` block with `custom_domain = true` to `apps/davidjfelix.com/wrangler.toml` so it's reproducible from config
+- [ ] Comment on this issue with the timestamp of cutover
+
+### Automation follow-up
+
+Codify the custom-domain attachment in `wrangler.toml` so future redeploys don't drift. After this cutover, document the pattern in `new-domain-sites` so the next 7 domains follow the same wrangler-config-first approach instead of dashboard clicks.
+
+### Related
+
+- [New Domain Sites](docs/projects/new-domain-sites/plan.md)
+- `apps/davidjfelix.com/wrangler.toml`
+- Latest progress: `docs/projects/new-domain-sites/2026-04-30-progress.md`

--- a/docs/reading-list.md
+++ b/docs/reading-list.md
@@ -1,0 +1,27 @@
+# Reading List
+
+Books on shelf, waiting to be read. Migrated out of GitHub issues on 2026-05-13 — issues weren't the right home for a reading list.
+
+> [!NOTE]
+> This is a temporary home. At some point this should move into notes proper, alongside the rest of the personal reference material.
+
+## Fiction
+
+- [ ] **Wind and Truth: Book Five of the Stormlight Archive** — audiobook (Audible)
+- [ ] **Cibola Burn: The Expanse, Book 4** — audiobook (Audible)
+- [ ] **Gideon the Ninth (The Locked Tomb Series, 1)** — audiobook (Audible). Recommended by Summer.
+- [ ] **No Country for Old Men** — print
+- [ ] **Blood Meridian** — print
+- [ ] **The Road** — print
+- [ ] **Zen and the Art of Motorcycle Maintenance** — print
+
+## Non-Fiction
+
+- [ ] **A Brief History of Intelligence** — audiobook (Audible)
+- [ ] **Art & Fear: Observations On the Perils (and Rewards) of Artmaking** — audiobook (Audible)
+- [ ] **How to Win Friends & Influence People** — print
+- [ ] **Shortcut Your Startup: Ten Ways to Speed Up Entrepreneurial Success** — print
+- [ ] **The Prince** — Kindle / print
+- [ ] **The SaaS Playbook: Build a Multimillion-Dollar Startup Without Venture Capital** — print
+- [ ] **The Meritocracy Trap: How America's Foundational Myth Feeds Inequality, Dismantles the Middle Class, and Devours the Elite** — print
+- [ ] **How to Decide** — print. Recommended by Jeremey D.


### PR DESCRIPTION
## Summary

Adds two new documentation files to capture work that requires human intervention and personal reference material that was previously scattered across GitHub issues.

## Changes

- **docs/pending-issues.md** — Drafts of four GitHub issues awaiting filing once the GitHub MCP server is back online:
  - Install Warp CLI locally (blocks `setup-warp` project)
  - Create Sentry org and per-app projects (blocks `sentry-integration` rollout)
  - Create PostHog org and per-app projects (blocks `posthog-integration` rollout)
  - DNS cutover for davidjfelix.com (blocks `new-domain-sites` completion)

  Each issue follows the new "Human Intervention Tasks" format with Background, Steps, Automation follow-up, and Related sections.

- **docs/reading-list.md** — Personal reading list (fiction and non-fiction) migrated out of GitHub issues, with a note that this is temporary pending integration into a proper notes system.

- **CLAUDE.md** — Added "Human Intervention Tasks" section documenting the format and requirements for issues that require David's hands-on work (local machine setup, credentials, third-party account decisions, DNS changes, etc.). Specifies that such issues must include Background, Steps (as a checklist), Automation follow-up, and Related sections, and should fit on one screen.

## Changelog entry

```markdown
### docs(repo): add pending issues and reading list

Added `docs/pending-issues.md` with drafts of four GitHub issues awaiting MCP filing (Warp CLI install, Sentry setup, PostHog setup, DNS cutover). Added `docs/reading-list.md` for personal reading list. Documented "Human Intervention Tasks" format in CLAUDE.md for issues requiring human login, local setup, or credential management.
```

## Testing

- [x] Builds successfully
- [x] Manually verified — files follow CLAUDE.md conventions and are properly formatted

https://claude.ai/code/session_01HbCeWJ2B5E47Us8WRrjeMy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add guidelines and draft issue templates; no code paths, runtime behavior, or data handling are affected.
> 
> **Overview**
> Adds a new **"Human Intervention Tasks"** section to `CLAUDE.md` that standardizes when and how to file GitHub issues for work requiring local access/credentials, including required sections and brevity constraints.
> 
> Introduces `docs/pending-issues.md` with four ready-to-file issue drafts (Warp install, Sentry setup, PostHog setup, and Cloudflare DNS cutover) and adds `docs/reading-list.md` to store a personal reading list migrated out of GitHub issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe599ecd80ad39435b3689aad4196dd2644a3df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->