### PR TITLE
docs(repo): document mise tool version management workflow

### DIFF
--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -36,7 +36,11 @@ jobs:
         # mise install during the previous step updates .config/mise.lock if
         # mise.toml has gained or bumped a tool. A non-empty diff here means
         # whoever changed mise.toml forgot to commit the lockfile update.
-        run: git diff --exit-code .config/mise.lock
+        run: |
+          if ! git diff --exit-code .config/mise.lock; then
+            echo "::error file=.config/mise.lock::.config/mise.lock is out of date. Run 'mise install' locally (with GITHUB_TOKEN set, or 'gh auth login' first) and commit the updated lockfile. See CONTRIBUTING.md for details."
+            exit 1
+          fi
 
       - name: actionlint
         run: actionlint

--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -32,6 +32,12 @@ jobs:
           install: true
           cache: true
 
+      - name: Verify mise.lock matches mise.toml
+        # mise install during the previous step updates .config/mise.lock if
+        # mise.toml has gained or bumped a tool. A non-empty diff here means
+        # whoever changed mise.toml forgot to commit the lockfile update.
+        run: git diff --exit-code .config/mise.lock
+
       - name: actionlint
         run: actionlint
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,14 @@ Add an entry to the current month's file in `docs/changelog/`. Create the monthl
 - Use tooling defined in `.config/mise.toml` (Biome, Oxlint, Prettier)
 - See per-app `package.json` scripts for lint/format/spell commands
 
+## Tool versions: `.config/mise.toml` and `.config/mise.lock`
+
+`.config/mise.toml` declares the tools and version ranges this repo uses; `.config/mise.lock` pins them to exact versions (with per-platform URLs and checksums) so every machine and CI runner installs the same bits.
+
+Whenever you add a tool to `mise.toml` or bump a version, run `mise install` and commit the resulting `mise.lock` changes in the same PR. The Actions hygiene workflow runs `git diff --exit-code .config/mise.lock` after `mise install` and fails if the lockfile is stale.
+
+If `mise install` cannot reach the GitHub releases API (rate limit / sandbox), set `GITHUB_TOKEN` (a no-scope PAT works) and retry. Do not skip the lockfile update — the CI check will catch it.
+
 ## Project lifecycle
 
 Project directories under `docs/projects/<name>/` are working notes -- plan, progress, open questions. They exist to coordinate work in flight, not to serve as history.


### PR DESCRIPTION
## Summary

Add documentation and CI enforcement for the `mise.toml` / `mise.lock` workflow. This ensures that whenever tools or versions are updated, the lockfile is committed in the same PR, preventing stale lockfile issues in CI.

## Changes

- **CONTRIBUTING.md**: Added new "Tool versions" section explaining the purpose of `.config/mise.toml` and `.config/mise.lock`, the requirement to run `mise install` and commit lockfile changes, and troubleshooting for GitHub API rate limits.
- **actions-lint.yml**: Added a new CI step that runs `git diff --exit-code .config/mise.lock` after `mise install` to catch stale lockfiles before they merge.

## Changelog entry

```markdown
### docs(repo): document mise tool version management workflow

Added guidance in CONTRIBUTING.md on maintaining `.config/mise.lock` whenever tools are added or bumped in `.config/mise.toml`. Added CI check in actions-lint.yml to verify the lockfile is up-to-date, preventing stale lockfiles from merging.
```

## Testing

- [x] CI workflow syntax is valid (actionlint will verify)
- [x] Documentation is clear and follows existing CONTRIBUTING.md style

https://claude.ai/code/session_017n9maT14hzmsVXET6uVwAe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a CI guardrail and documentation only, with the main impact being stricter PR validation when `.config/mise.toml` changes without updating `.config/mise.lock`.
> 
> **Overview**
> Adds CI enforcement to keep `.config/mise.lock` in sync with `.config/mise.toml` by failing the Actions hygiene workflow if `mise install` would change the lockfile.
> 
> Documents the expected `mise.toml`/`mise.lock` workflow in `CONTRIBUTING.md`, including requiring `mise install` + committing lockfile updates and guidance for GitHub API rate-limit issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e58fe8128e7a807afabffdd44083165c585600c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->