### PR TITLE
config(davidjfelix.com): codify custom domain routes in wrangler.toml

### DIFF
--- a/apps/davidjfelix.com/wrangler.toml
+++ b/apps/davidjfelix.com/wrangler.toml
@@ -2,5 +2,10 @@
 name = "davidjfelix-com"
 compatibility_date = "2026-04-29"
 
+routes = [
+  { pattern = "davidjfelix.com", custom_domain = true },
+  { pattern = "www.davidjfelix.com", custom_domain = true },
+]
+
 [assets]
 directory = "./dist"


### PR DESCRIPTION
## Summary

- Adds `routes` block with `custom_domain = true` for `davidjfelix.com` and `www.davidjfelix.com` to `apps/davidjfelix.com/wrangler.toml` so the dashboard attachment is reproducible from config.
- Closes the final two checkboxes on #96 (DNS cutover already completed manually).

## Test plan

- [ ] `wrangler deploy` from `apps/davidjfelix.com` succeeds without dashboard drift
- [ ] `https://davidjfelix.com` and `https://www.davidjfelix.com` continue to serve the site

Closes #96

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzxCQsoU5nsgkEyk1Tnw6K)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it just declares the Cloudflare Worker custom-domain routes and could affect routing if misconfigured.
> 
> **Overview**
> Adds a `routes` block to `apps/davidjfelix.com/wrangler.toml` to explicitly attach the worker to the `davidjfelix.com` and `www.davidjfelix.com` custom domains (with `custom_domain = true`), making the deployment configuration reproducible from code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97837875964077a77126d0190df0b68886e6781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->