### PR TITLE
chore(tooling): simplify claude-code-action prompt configuration

### DIFF
--- a/.github/workflows/bot_claude_code_review.yml
+++ b/.github/workflows/bot_claude_code_review.yml
@@ -44,6 +44,6 @@ jobs:
           allowed_bots: 'claude[bot],dependabot[bot],renovate[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

Simplifies the Claude code review bot prompt by removing the hardcoded pull request URL and using the `--comment` flag instead, which allows the action to automatically detect and comment on the current PR.

## Changes

- Replaced the explicit PR URL construction (`${{ github.repository }}/pull/${{ github.event.pull_request.number }}`) with the `--comment` flag
- This delegates PR detection to the claude-code-action, reducing configuration complexity and potential for URL construction errors

## Changelog entry

```markdown
### chore(tooling): simplify claude-code-action prompt configuration

Replaced hardcoded PR URL in code review bot prompt with `--comment` flag for automatic PR detection.
```

## Testing

- [ ] Builds successfully
- [ ] Code review bot successfully comments on pull requests

https://claude.ai/code/session_01VvuyRRP9kfTfYMpGjNKEnJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that alters how the review bot targets the PR; main risk is the action failing to auto-detect/comment as expected.
> 
> **Overview**
> Simplifies the Claude code review GitHub Action configuration by replacing the explicit PR URL in the `prompt` with the `--comment` flag, delegating PR detection and commenting to `claude-code-action`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a82f9698fd297c82bd02593ff4e432f8cf62b488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->