### PR TITLE
Grant tools and raise limits for dependency-freshness cron

### DIFF
--- a/.github/workflows/dependency-freshness.yml
+++ b/.github/workflows/dependency-freshness.yml
@@ -10,7 +10,7 @@ jobs:
   freshness:
     name: dependency-freshness sweep
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write
@@ -38,6 +38,14 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |
             actions: read
+          # Unattended run on an ephemeral, isolated runner. The skill needs
+          # broad tool access (pnpm, cargo, mise, git, the GitHub MCP tools);
+          # the real boundary is this job's `permissions:` block above, not a
+          # tool allowlist. --max-turns is raised well past a single sweep's
+          # needs since one run can open many PRs.
+          claude_args: |
+            --max-turns 150
+            --dangerously-skip-permissions
           prompt: |
             Run the dependency-freshness skill for all ecosystems (npm, mise,
             Cargo). Discover, evaluate, apply, verify, and open PRs exactly as


### PR DESCRIPTION
## Summary

Follow-up to #111. After the auth fix landed, a `workflow_dispatch` run of the `dependency-freshness` workflow hit **56 permission denials** — the default `claude-code-action` toolset can't run `pnpm`/`cargo`/`git` or the GitHub MCP tools the skill needs. `bot_claude.yml` doesn't hit this because a human `@claude` trigger in a PR context auto-grants more; an unattended `workflow_dispatch` doesn't.

- Add `claude_args` with `--dangerously-skip-permissions` and `--max-turns 150`.
- Raise the job `timeout-minutes` from 30 to 60 so a full multi-PR sweep can finish.

On the security posture: the runner is ephemeral and isolated, and the job's `permissions:` block (`contents: write`, `pull-requests: write`, `issues: write`) is the real boundary on what the run can do to the repo — a tool allowlist that still has to include `Bash` + `mcp__github__*` wouldn't add a meaningful boundary.

## Test plan

- [ ] Merge, then re-run the `dependency-freshness` workflow via `workflow_dispatch` and confirm it discovers updates and opens PR(s) without permission denials.

https://claude.ai/code/session_01Qz2cPGv4p6Dfkch76uvneE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qz2cPGv4p6Dfkch76uvneE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it explicitly disables the `claude-code-action` tool permission gate for an unattended workflow and increases agent autonomy, which could widen the blast radius of any prompt/tooling misuse within the job’s repo write permissions.
> 
> **Overview**
> Increases the `dependency-freshness` GitHub Action timeout from 30 to 60 minutes to better accommodate full multi-ecosystem update sweeps.
> 
> Updates the `claude-code-action` step to pass `claude_args` that raise `--max-turns` to 150 and enable `--dangerously-skip-permissions`, allowing broader tool/GitHub MCP usage during unattended runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96da8d0b7e94fb4545eedaa8c83de8382858076e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->