### PR TITLE
chore(f311x): migrate to TypeScript native preview

### DIFF
--- a/apps/f311x/.vscode/settings.json
+++ b/apps/f311x/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+  "typescript.tsdk": "node_modules/@typescript/native-preview/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
   "files.watcherExclude": {
     "**/routeTree.gen.ts": true
   },

--- a/apps/f311x/package.json
+++ b/apps/f311x/package.json
@@ -55,7 +55,6 @@
     "@typescript/native-preview": "latest",
     "@vitejs/plugin-react": "^6.0.1",
     "jsdom": "^28.1.0",
-    "typescript": "^6.0.2",
     "vite": "^8.0.0",
     "vitest": "^4.1.5",
     "wrangler": "^4.92.0"

--- a/apps/f311x/package.json
+++ b/apps/f311x/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "spell": "cspell --config ../../.config/cspell.json \"**\"",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -52,6 +52,7 @@
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "@typescript/native-preview": "latest",
     "@vitejs/plugin-react": "^6.0.1",
     "jsdom": "^28.1.0",
     "typescript": "^6.0.2",

--- a/apps/f311x/pnpm-lock.yaml
+++ b/apps/f311x/pnpm-lock.yaml
@@ -105,9 +105,6 @@ importers:
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0
-      typescript:
-        specifier: ^6.0.2
-        version: 6.0.3
       vite:
         specifier: ^8.0.0
         version: 8.0.13(@types/node@22.19.19)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)
@@ -3543,11 +3540,6 @@ packages:
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
-
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -7278,8 +7270,6 @@ snapshots:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
-
-  typescript@6.0.3: {}
 
   ufo@1.6.4: {}
 

--- a/apps/f311x/pnpm-lock.yaml
+++ b/apps/f311x/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.0
         version: 19.2.3(@types/react@19.2.14)
+      '@typescript/native-preview':
+        specifier: latest
+        version: 7.0.0-dev.20260522.1
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.1)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -1960,6 +1963,53 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-kp2JX8wSCQ5i8f5Zr30t9TdAIEw8s3MCvT1zEe6PJAHU7aUHTnRCM+oAHEM8QxM29VD/PxR6b5dVKxHtX7Ny/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-jX89E/hV/r0fOcP4+JWdKSugJXmWbOO74aC5a1U8+U7TBD1TTfK50Da+BL8Sf2Xud2ybqQ+2FUHAlBsLTC743g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-XFLpJNscLKqT6LLSBrv78DzLdzwFYOePeluRBF616KUPEcfiXliTan1YuHQh4m9i9o6tvW/NnuAPlr/Q8DObsg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-vItWfPtZfUQLaVJe0iClfsKSDtkUCUTp2LfEXBHqBCdWhoE3irg7Ivs41l3sp4zXlTio5SUvMzvO8/Mc2SImzA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-r5wkbqL+qpI3QN3GiF0dg5A0PD5x9cfYSSCD744+Ov35P8inuJSySjR44gdoOF3IcFTupPEc/4q4to/gId1kZQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-Xtqw0dfE35WISVqN2J9hp21N6l5MT21DSgJ4w/cXisDZlaeT0Vq57CgUWUbLT4CEw5gs0QK6kmUFOSAP7Dga6Q==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-CBTpf7skuTNgHzjwEbw3ujU76r/u9asENXc9xQmgj6qCJ1+ZHn34MMzolkUegwtHWfuem38ayYTJOMn2dmNQ5g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260522.1':
+    resolution: {integrity: sha512-NgnE3PE3/nr4Qr8p1uCIkaM5YmNa8hQGhzb8Olb6w09aocg4Wq8bjrFHe4qZH2kgV+Hl4gGXRNb9ww1P2fwc9Q==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -5600,6 +5650,37 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.19
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260522.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260522.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260522.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260522.1
 
   '@vercel/oidc@3.2.0': {}
 


### PR DESCRIPTION
## Summary

Migrate the f311x app from the standard TypeScript compiler to the native preview implementation (`@typescript/native-preview`). This includes updating the typecheck script to use `tsgo` and configuring VS Code to use the native TypeScript SDK.

## Changes

- Replace `typescript` dependency with `@typescript/native-preview`
- Update `typecheck` script from `tsc --noEmit` to `tsgo --noEmit`
- Configure VS Code to use the native TypeScript SDK via `typescript.tsdk` setting
- Enable workspace TypeScript SDK prompt in VS Code settings

## Changelog entry

```markdown
### chore(f311x): migrate to TypeScript native preview

Switched from the standard TypeScript compiler to the native preview implementation for improved performance. Updated the typecheck script and VS Code configuration accordingly.
```

## Testing

- [x] Builds successfully
- [x] Typecheck passes with new `tsgo` command
- [x] VS Code recognizes the native TypeScript SDK

https://claude.ai/code/session_01GfAVeFSRFgo1vHxSTmXcdb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches the app’s typechecking toolchain from `tsc` to the preview `tsgo` compiler, which could surface new/different type errors or affect CI/dev workflows due to the pinned dev preview binaries.
> 
> **Overview**
> Migrates `apps/f311x` typechecking from the standard TypeScript compiler to the native preview toolchain by replacing `tsc --noEmit` with `tsgo --noEmit` and swapping the `typescript` dev dependency for `@typescript/native-preview`.
> 
> Updates workspace editor configuration to use the native preview TypeScript SDK in VS Code, and refreshes the lockfile to include the new platform-specific native preview packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 687f5c3a061bfd02e893ac806eac0c7becc00159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->