### PR TITLE
fix(ci): use client-id and valid permission in cron renovate

### DIFF
--- a/.github/workflows/cron_renovate.yml
+++ b/.github/workflows/cron_renovate.yml
@@ -3,11 +3,11 @@ name: Cron Renovate
 # Self-hosted Renovate runner. Reads .github/renovate.json for repo config
 # (batching, schedule, lockFileMaintenance, vulnerability handling).
 #
-# Authenticates as a GitHub App via RENOVATE_APP_ID + RENOVATE_APP_PRIVATE_KEY
+# Authenticates as a GitHub App via RENOVATE_CLIENT_ID + RENOVATE_APP_PRIVATE_KEY
 # secrets. The App pattern (vs. a PAT) gets higher API rate limits, lets
 # Renovate PRs trigger downstream CI workflows, and is portable to the
 # closed-source repos that want to copy this setup. App setup is tracked
-# in #140.
+# in #141.
 on:
   schedule:
     # Hourly wake-up. Actual PR cadence is controlled by the `schedule:`
@@ -37,7 +37,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           # Scope the minted token to least privilege — without these the
           # token inherits the App's full installation permissions.
@@ -46,7 +46,7 @@ jobs:
           permission-issues: write
           permission-workflows: write
           permission-checks: read
-          permission-dependabot-alerts: read
+          permission-vulnerability-alerts: read
 
       - name: renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14


### PR DESCRIPTION
The create-github-app-token action deprecated `app-id` in favor of
`client-id`, and `permission-dependabot-alerts` is not a valid input —
the repository permission for Dependabot alerts is `vulnerability-alerts`.

- Switch `app-id` -> `client-id` (sourced from new RENOVATE_CLIENT_ID secret)
- Fix `permission-dependabot-alerts` -> `permission-vulnerability-alerts`
- Update stale #140 reference to #141 (the live App-setup issue)

The hard "client-id must be non-empty" failure remains until the App
secrets exist; that is the human task tracked in #141.

https://claude.ai/code/session_018LNHSfKDCAXboesjptvs8S

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow input and comment fixes; no runtime app or auth logic changes beyond matching the GitHub Action API.
> 
> **Overview**
> Updates the **Cron Renovate** workflow so GitHub App token minting matches current `actions/create-github-app-token` inputs and valid repository permissions.
> 
> The mint step now uses **`client-id`** from `RENOVATE_CLIENT_ID` instead of deprecated **`app-id`** / `RENOVATE_APP_ID`, and requests **`permission-vulnerability-alerts`** instead of the invalid **`permission-dependabot-alerts`**. Comments point at **`#141`** for App setup and the new secret name.
> 
> The workflow will still fail until **`RENOVATE_CLIENT_ID`** and related App secrets exist (tracked in #141).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b3e47c4ca23e2aad490eabfab16bc29d07a0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->