### PR TITLE
fix(ci): get cron renovate running (client-id, valid permission, repo scope)

### DIFF
--- a/.github/workflows/cron_renovate.yml
+++ b/.github/workflows/cron_renovate.yml
@@ -54,3 +54,10 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           # Per-repo config is auto-discovered from .github/renovate.json;
           # no configurationFile needed.
+        env:
+          # The minted App token behaves like a PAT, so Renovate has no
+          # implicit repo to act on — without this it logs "No repositories
+          # found" and exits. Scope it to just this repo, which also keeps
+          # the one-App-across-N-repos pattern clean: each repo's workflow
+          # runs Renovate only against itself.
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## What

Fixes the `Cron Renovate` workflow so it runs clean and actually does work. Three changes:

1. **`app-id` → `client-id`** — `actions/create-github-app-token` deprecated `app-id`. The `client-id` input takes the App's *Client ID* (not the numeric App ID), so the secret is now `RENOVATE_CLIENT_ID`.
2. **`permission-dependabot-alerts` → `permission-vulnerability-alerts`** — the first is not a valid action input; the repo permission for Dependabot alerts is `vulnerability-alerts`. (Fixes the "Unexpected input" warning.)
3. **`RENOVATE_REPOSITORIES: ${{ github.repository }}`** — the minted App token behaves like a PAT, so Renovate had no repo to operate on and exited with `No repositories found`. Scoping to the current repo also keeps the one-App-across-N-repos pattern clean (each repo's workflow runs Renovate only against itself).

Also fixed a stale `#140` → `#141` reference in the workflow header comment.

## Why

The cron was failing/no-op'ing: two warnings plus a hard `client-id must be non-empty` error (missing secrets), and after secrets were added it ran green but did nothing (`No repositories found`).

## Notes

- Issue #141 (the human App-setup task) has been updated to capture the App **Client ID** as `RENOVATE_CLIENT_ID`.
- After merge, the next scheduled cron (or a manual **Run workflow**) should open the **Dependency Dashboard** issue and the initial batched PRs. The repo is already onboarded via the existing `.github/renovate.json`, so no onboarding PR is expected.

## Related

- #141 — Renovate GitHub App setup (human task)
- Config: `.github/renovate.json`

https://claude.ai/code/session_018LNHSfKDCAXboesjptvs8S

---
_Generated by [Claude Code](https://claude.ai/code/session_018LNHSfKDCAXboesjptvs8S)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Fixes the scheduled **Cron Renovate** workflow so Renovate actually runs against this repository instead of exiting with *No repositories found*.
> 
> The **renovate** step now sets **`RENOVATE_REPOSITORIES`** to **`${{ github.repository }}`**, because an App-minted token (like a PAT) does not imply a default repo. That scopes each workflow run to the current repo only, which fits a single App used across multiple repositories.
> 
> Related workflow fixes (App **`client-id`** / **`RENOVATE_CLIENT_ID`**, valid **`permission-vulnerability-alerts`**, and comment updates) align token minting and permissions so the cron can authenticate and run cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b0db5cbdd167c8b420084bdcc79b9dfadede0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->