### PR TITLE
Fix mise trust error in Renovate workflow

### DIFF
--- a/.github/workflows/cron_renovate.yml
+++ b/.github/workflows/cron_renovate.yml
@@ -62,3 +62,6 @@ jobs:
           # the one-App-across-N-repos pattern clean: each repo's workflow
           # runs Renovate only against itself.
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # Auto-trust mise config files in Renovate's ephemeral checkout
+          # so `mise lock` doesn't fail on untrusted paths.
+          MISE_YES: '1'


### PR DESCRIPTION
## Problem

The Renovate job fails to update `.config/mise.lock` because mise refuses to run `mise lock node` against an untrusted config:

```
mise ERROR Config files in /tmp/renovate/repos/github/DavidJFelix/DavidJFelix/.config/mise.toml are not trusted.
mise ERROR Trust them with `mise trust`.
```

Renovate clones the repo into an ephemeral path (`/tmp/renovate/repos/...`) that mise's path-based trust mechanism doesn't recognize, so the lock update produces an empty commit and aborts.

## Fix

Set `MISE_YES: '1'` in the Renovate step's environment. This makes mise auto-approve trust prompts without interaction — the standard approach for CI, and safe here since the config comes from our own repo checkout.

https://claude.ai/code/session_01H7YeE11yN759H5YN5iijjw

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YeE11yN759H5YN5iijjw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI env var for Renovate only; no runtime, auth, or application code changes.
> 
> **Overview**
> The Renovate cron workflow now sets **`MISE_YES: '1'`** on the Renovate step so mise auto-approves trust for config in Renovate’s ephemeral clone path. That unblocks **`mise lock`** updates to **`.config/mise.lock`** when Renovate bumps mise-managed tools, which previously failed with “config files are not trusted” and produced empty commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50db7c3b6a7f85b0cbe78ad5d9ecfd7176b7a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->