### PR TITLE
Move MISE_YES to Renovate customEnvVariables

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
-  "customEnvVariables": {
-    "MISE_YES": "1"
-  },
   "timezone": "UTC",
   "schedule": ["before 5am on monday"],
   "lockFileMaintenance": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
+  "customEnvVariables": {
+    "MISE_YES": "1"
+  },
   "timezone": "UTC",
   "schedule": ["before 5am on monday"],
   "lockFileMaintenance": {

--- a/.github/workflows/cron_renovate.yml
+++ b/.github/workflows/cron_renovate.yml
@@ -62,6 +62,3 @@ jobs:
           # the one-App-across-N-repos pattern clean: each repo's workflow
           # runs Renovate only against itself.
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          # Auto-trust mise config files in Renovate's ephemeral checkout
-          # so `mise lock` doesn't fail on untrusted paths.
-          MISE_YES: '1'

--- a/.github/workflows/cron_renovate.yml
+++ b/.github/workflows/cron_renovate.yml
@@ -62,3 +62,4 @@ jobs:
           # the one-App-across-N-repos pattern clean: each repo's workflow
           # runs Renovate only against itself.
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_CUSTOM_ENV_VARIABLES: '{"MISE_YES":"1"}'


### PR DESCRIPTION
## Problem

PR #195 set `MISE_YES=1` on the workflow step's `env:` block, but that doesn't reach `mise lock` — Renovate spawns it as a child process with a hardcoded env allowlist:

```
"env": ["GITHUB_TOKEN", "HOME", "PATH", "LC_ALL", "LANG", "CONTAINERBASE_CACHE_DIR"]
```

`MISE_YES` never makes it through, so `mise lock` still fails with "config files are not trusted."

## Fix

- Add `"customEnvVariables": { "MISE_YES": "1" }` to `.github/renovate.json` — this is Renovate's mechanism for injecting env vars into child processes
- Remove the ineffective `MISE_YES` from the workflow `env:` block

https://claude.ai/code/session_01H7YeE11yN759H5YN5iijjw

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YeE11yN759H5YN5iijjw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the Renovate GitHub Actions workflow env wiring; no application or security-sensitive runtime code.
> 
> **Overview**
> Renovate’s cron workflow no longer sets **`MISE_YES`** on the step’s plain `env:` block (that env never reached child processes like **`mise lock`**, which only inherit Renovate’s allowlisted variables).
> 
> Instead it sets **`RENOVATE_CUSTOM_ENV_VARIABLES`** to `{"MISE_YES":"1"}` so Renovate injects **`MISE_YES`** into spawned commands, avoiding “config files are not trusted” failures during lock updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ab0aa1bc5ca6fa92bfade8e66618c83be29c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->