### PR TITLE
docs(f311x): record 2026-06-06 deploy session and token scopes

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -58,7 +58,7 @@ Stand up sites for 8 owned domains across Astro, TanStack Start, Vue, and Svelte
 
 ### [f311x.com](./projects/f311x/plan.md)
 
-Effect-native AI agent app on Cloudflare: TanStack Start + Cloudflare Agents SDK + Alchemy v2, with Effect-TS owning async orchestration.
+A small chat app on Cloudflare — TanStack Start front end, deployed via Alchemy v2. Builds and deploys today (CD live as of 2026-06-06); the chat backend isn't wired yet.
 
 **Status**: In Progress
 

--- a/docs/projects/f311x/2026-06-06-progress.md
+++ b/docs/projects/f311x/2026-06-06-progress.md
@@ -1,0 +1,56 @@
+# 2026-06-06 progress
+
+## Session summary
+
+The first production `alchemy deploy` for f311x (via `cd_deploy_f311x.yml`) failed
+with `Unauthorized: Authentication error` (Cloudflare API error `10000`), then
+went green once the CI token was granted **Secrets Store: Edit**.
+
+## What happened
+
+- The deploy died ~1s in, inside the Alchemy CLI's shared setup (`_shared.js`),
+  *before* the resource phase — i.e. while bootstrapping state, not while creating
+  R2 buckets.
+- Root cause: the `CLOUDFLARE_API_TOKEN` lacked **Secrets Store: Edit**. Alchemy's
+  `Cloudflare.state()` stores/reads deployment state via Cloudflare Secrets Store,
+  so the CLI 401s at startup without it. This is a CLI *state-access* scope, **not**
+  a resource scope — the token already had Workers / R2 / AI Gateway.
+- Cloudflare surfaces the missing scope as a generic `10000 "Authentication
+  error"`, which made it look (wrongly) like a bad/expired token or an R2 problem.
+- Ruled out token/account issues first: the same `CLOUDFLARE_*` secrets already
+  deploy djf.io, davidjfelix.com, calendar-visualizer, and ravrun via wrangler, and
+  the local `dev_${USER}` deploy had already created the dev-stage R2 buckets, the
+  `f311x-website-dev-*` Worker, and the `alchemy-state-store` Worker — so the
+  account/token pair was valid all along.
+
+## Resolution
+
+- Granted the CI token **Secrets Store: Edit** (per the Alchemy CI/CD guide).
+- Re-ran the deploy; prod resources created and the deploy is green.
+- Recorded the required token scopes in `plan.md` so a token rotation or a new
+  Alchemy app doesn't have to rediscover this.
+
+## Decisions made
+
+- Keep the required-scope list in `plan.md` as the durable record, not just here.
+- Filed an upstream issue against Alchemy: the CI/CD guide (and ideally the error
+  message) should call out that `Cloudflare.state()` needs Secrets Store: Edit.
+
+## Next steps
+
+- Optional: add `workflow_dispatch` to `cd_deploy_f311x.yml` so prod deploys can be
+  re-run on demand without an empty commit.
+- Resume the real next job: wire a minimal agent backend behind
+  `/agents/chat-agent/default` that streams a reply.
+
+## Blockers or open questions
+
+- None.
+
+## Related
+
+- [plan.md](plan.md) — required token scopes
+- [2026-06-03-progress.md](2026-06-03-progress.md) — CD wiring + the untested
+  permission assumption this run resolved
+- [`cd_deploy_f311x.yml`](../../../.github/workflows/cd_deploy_f311x.yml)
+- [`alchemy.run.ts`](../../../apps/f311x/alchemy.run.ts) — `Cloudflare.state()`

--- a/docs/projects/f311x/plan.md
+++ b/docs/projects/f311x/plan.md
@@ -3,15 +3,17 @@
 A small chat app on Cloudflare — TanStack Start front end, deployed via Alchemy v2.
 "f311x" is the agent. Today it builds and deploys; the chat backend isn't wired yet.
 
-## Current state (2026-06-03)
+## Current state (2026-06-06)
 
 - **Builds + deploys.** TanStack Start client app (`src/routes`, `src/components/ui`).
   `pnpm typecheck`, `pnpm build`, and `pnpm test` are green, and CI gates all of
   them (`.github/workflows/ci_f311x.yml`).
 - **CD wired.** `.github/workflows/cd_deploy_f311x.yml` runs `alchemy deploy
   --stage prod` on push to main, using the shared `CLOUDFLARE_*` secrets (CI is
-  gated at merge via branch protection, not the deploy workflow). The first real
-  run is still pending — see the 2026-06-03 progress note.
+  gated at merge via branch protection, not the deploy workflow). The first prod
+  deploy succeeded on 2026-06-06, after granting the CI token **Secrets Store:
+  Edit** — the Alchemy CLI needs it to read/write `Cloudflare.state()`, which is a
+  CLI state scope, not a resource scope. See the 2026-06-06 progress note.
 - **Chat is a shell.** `src/routes/index.tsx` posts to `/agents/chat-agent/default`,
   which has no backend — sending a message goes nowhere yet.
 - The earlier Effect-native scaffold (effects services, a custom Vectorize provider,
@@ -34,6 +36,25 @@ A small chat app on Cloudflare — TanStack Start front end, deployed via Alchem
 - Tailwind v4 + shadcn-style components
 - Alchemy v2 for deploy + bindings (`alchemy.run.ts`, which uses `effect`)
 - Vitest + Testing Library + jsdom for tests
+
+## CI deploy — required Cloudflare token scopes
+
+`cd_deploy_f311x.yml` runs `alchemy deploy --stage prod` with the shared
+`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets (account
+`184b85b87e2289c4b18d7aaf41cd53cd`). The token must carry:
+
+- **Secrets Store · Edit** — Alchemy's `Cloudflare.state()` reads/writes deploy
+  state via Cloudflare Secrets Store, so the CLI 401s at startup without it. This
+  gates the CLI's *state access*, not a resource — and its absence is what failed
+  the first deploy. Cloudflare reports it as a generic `10000 "Authentication
+  error"`, which misleadingly looks like a bad token or a missing R2 scope.
+- **Workers Scripts · Edit** — deploy the Worker (same scope wrangler uses for the
+  other apps, so this was already present).
+- **Workers R2 Storage · Edit** — the `Uploads` / `AgentWorkspace` buckets.
+- **AI Gateway · Edit** — the `Gateway` AI Gateway.
+
+Only **Secrets Store: Edit** was missing on the first run; the resource scopes were
+already granted. See the Alchemy CI/CD guide and the 2026-06-06 progress note.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

Document the first successful production deploy of f311x after resolving a Cloudflare API token permission issue. The CI token was missing **Secrets Store: Edit**, which Alchemy's `Cloudflare.state()` requires to read/write deployment state — a CLI bootstrap scope, not a resource scope.

## Changes

- Added `2026-06-06-progress.md` recording the deploy failure, root cause analysis, and resolution
- Updated `plan.md` to reflect current state (CD live as of 2026-06-06) and document required Cloudflare token scopes for CI deploys
- Updated `docs/projects.md` summary to reflect that f311x now builds, deploys, and has live CD

## Changelog entry

```markdown
### docs(f311x): record first successful prod deploy and required token scopes

Documented the 2026-06-06 production deploy of f311x, which initially failed due to missing **Secrets Store: Edit** on the CI token. Alchemy's `Cloudflare.state()` needs this scope to bootstrap (read/write deployment state), separate from resource scopes. Added required token scope list to plan.md for future reference and token rotations.
```

## Testing

- [x] Builds successfully
- [x] No tests affected (documentation only)
- [x] Manually verified — progress note accurately reflects the deploy session and resolution

https://claude.ai/code/session_01DvtGriD9JQ1STqVbUVv6G2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only project documentation with no runtime, CI workflow, or secret changes.
> 
> **Overview**
> **Documentation-only** update for f311x after the first green production Alchemy deploy on 2026-06-06.
> 
> Adds **`2026-06-06-progress.md`** with the deploy timeline: initial `10000` auth failure during Alchemy CLI bootstrap (`Cloudflare.state()` / Secrets Store), fix by granting **Secrets Store: Edit** on the shared CI token, and follow-ups (optional `workflow_dispatch`, wire chat agent).
> 
> Updates **`plan.md`** “current state” to CD-live as of 2026-06-06 and adds a durable **CI deploy — required Cloudflare token scopes** section (Secrets Store, Workers, R2, AI Gateway), clarifying that only Secrets Store was missing on the first run.
> 
> Refreshes the **`docs/projects.md`** f311x blurb to match reality (builds/deploys/CD live; chat backend still unwired) instead of the older Effect-native description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b39e79e6e35ef840d0e2055973d36a74c9c0ed2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->