### PR TITLE
feat(djf.io): remove AI attribution disclaimer from home page

### DIFF
--- a/apps/djf.io/src/pages/index.astro
+++ b/apps/djf.io/src/pages/index.astro
@@ -117,37 +117,5 @@ import BaseLayout from '../layouts/BaseLayout.astro'
         </ul>
       </div>
     </section>
-
-    <section
-      class={css({
-        bg: 'zinc.900',
-        p: '6',
-        borderRadius: 'lg',
-        border: '1px solid',
-        borderColor: 'zinc.800',
-      })}
-    >
-      <h2 class={css({fontSize: 'xl', fontWeight: 'bold', mb: '3'})}>
-        AI Attribution & Disclaimer
-      </h2>
-
-      <div class={css({'& p': {mb: '3', color: 'zinc.400', fontSize: 'sm'}})}>
-        <p>
-          I have not used generative AI, nor will I use any for generating written content
-          on this site. My goal is to express my ideas in written form. I utilize tools like
-          Grammarly and Hemingway to improve my writing, but I do not use generative fills
-          or "rewrite this sentence/paragraph" mechanics. I follow grammar and spelling
-          suggestions and auto-corrections for voice and tense. I use these tools because I
-          make mistakes, not because I need them to write for me.
-        </p>
-
-        <p>
-          I use Midjourney and OpenAI's DALL-E to generate illustrations for my posts when
-          writing alone might be too dry. My goal is to move away from using these tools
-          exclusively, but since I'm not an artist, that may take time. I will do my best to
-          identify all AI-generated images.
-        </p>
-      </div>
-    </section>
   </div>
 </BaseLayout>

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -2,6 +2,12 @@
 
 ## 2026-06-10
 
+### feat(djf.io): remove AI attribution disclaimer from home page
+
+Dropped the "AI Attribution & Disclaimer" section from the bottom of the home
+page (`src/pages/index.astro`). The policy statement read awkwardly and no
+longer reflects how the site is maintained.
+
 ### feat(djf.io): SEO meta, OG images, sitemap, JSON-LD; Lighthouse 100s
 
 Brought djf.io to production SEO polish and closed out `docs/projects/djf-io-seo/`.


### PR DESCRIPTION
## Summary

Removed the "AI Attribution & Disclaimer" section from the djf.io home page. The policy statement no longer reflects how the site is maintained and read awkwardly in its current form.

## Changes

- Deleted the entire "AI Attribution & Disclaimer" section from `src/pages/index.astro` (lines 120–151)
- Updated `docs/changelog/2026-06.md` with a changelog entry documenting the removal

## Changelog entry

```markdown
### feat(djf.io): remove AI attribution disclaimer from home page

Dropped the "AI Attribution & Disclaimer" section from the bottom of the home
page (`src/pages/index.astro`). The policy statement read awkwardly and no
longer reflects how the site is maintained.
```

## Testing

- [x] Builds successfully
- [x] Manually verified (section removed from rendered page)

https://claude.ai/code/session_01BQmh8hhPPf5B6bdUpUuK1H

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static marketing copy removal on a single page with no routing, auth, or data changes.
> 
> **Overview**
> Removes the **"AI Attribution & Disclaimer"** block from the bottom of the djf.io home page (`index.astro`). That section described writing/editing practices (Grammarly, Hemingway) and use of Midjourney/DALL-E for post illustrations.
> 
> Documents the change in `docs/changelog/2026-06.md` under **2026-06-10**, noting the copy felt awkward and no longer matches how the site is maintained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc5be4690ca49f8e42491987bf58bb9f2c0c404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->