### PR TITLE
fix(djf.io): use longhand border color properties to fix rendering

### DIFF
--- a/apps/djf.io/src/layouts/BaseLayout.astro
+++ b/apps/djf.io/src/layouts/BaseLayout.astro
@@ -66,7 +66,7 @@ const ogImageUrl = Astro.site ? new URL(ogImage, Astro.site) : undefined
     <header
       class={css({
         borderBottom: '1px solid',
-        borderColor: 'zinc.800',
+        borderBottomColor: 'zinc.800',
         py: '4',
       })}
     >
@@ -141,7 +141,7 @@ const ogImageUrl = Astro.site ? new URL(ogImage, Astro.site) : undefined
     <footer
       class={css({
         borderTop: '1px solid',
-        borderColor: 'zinc.800',
+        borderTopColor: 'zinc.800',
         py: '6',
         mt: '12',
       })}

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -2,6 +2,19 @@
 
 ## 2026-06-10
 
+### fix(djf.io): footer top border rendered near-white instead of zinc.800
+
+The footer paired the `borderTop: '1px solid'` shorthand with the `borderColor`
+shorthand. Panda emits each as its own atomic class, and `.bd-t_1px_solid` landed
+after `.bd-c_zinc.800` in the stylesheet, so the shorthand reset `border-top-color`
+back to `currentColor` -- the body's near-white `zinc.100` text color -- making the
+bar above the copyright line glow bright against the dark theme. The header only
+looked right because its `border-bottom` class happened to extract before the color
+class. Switched both header and footer to the `borderBottomColor` / `borderTopColor`
+longhands, which Panda deterministically sorts after shorthands, so the token color
+always wins regardless of extraction order. Verified via computed styles in
+Playwright: both borders now resolve to `rgb(39, 39, 42)`.
+
 ### feat(djf.io): remove AI attribution disclaimer from home page
 
 Dropped the "AI Attribution & Disclaimer" section from the bottom of the home


### PR DESCRIPTION
## Summary

Fixed a CSS specificity issue where footer and header borders were rendering in the wrong color due to Panda CSS emitting shorthand and longhand border properties as separate atomic classes. Switching to longhand `borderTopColor` and `borderBottomColor` ensures the color token always wins regardless of stylesheet extraction order.

## Changes

- Changed header `borderColor: 'zinc.800'` to `borderBottomColor: 'zinc.800'`
- Changed footer `borderColor: 'zinc.800'` to `borderTopColor: 'zinc.800'`
- Both borders now deterministically resolve to `rgb(39, 39, 42)` (zinc.800) instead of the body's text color

## Changelog entry

```markdown
### fix(djf.io): footer top border rendered near-white instead of zinc.800

The footer paired the `borderTop: '1px solid'` shorthand with the `borderColor`
shorthand. Panda emits each as its own atomic class, and `.bd-t_1px_solid` landed
after `.bd-c_zinc.800` in the stylesheet, so the shorthand reset `border-top-color`
back to `currentColor` -- the body's near-white `zinc.100` text color -- making the
bar above the copyright line glow bright against the dark theme. The header only
looked right because its `border-bottom` class happened to extract before the color
class. Switched both header and footer to the `borderBottomColor` / `borderTopColor`
longhands, which Panda deterministically sorts after shorthands, so the token color
always wins regardless of extraction order. Verified via computed styles in
Playwright: both borders now resolve to `rgb(39, 39, 42)`.
```

## Testing

- [x] Manually verified via computed styles in Playwright
- [x] Both borders now resolve to `rgb(39, 39, 42)` (zinc.800)

https://claude.ai/code/session_01J7NQttfTDWcGVCurppCENQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only layout styling in BaseLayout with no security, data, or API impact.
> 
> **Overview**
> Fixes **header and footer borders** on djf.io that could render as near-white instead of `zinc.800` when Panda CSS emits `borderTop`/`borderBottom` shorthands **after** the shared `borderColor` atomic class, resetting side color to `currentColor` (body text).
> 
> `BaseLayout.astro` now uses **`borderBottomColor`** and **`borderTopColor`** longhands so the token color consistently wins over extraction order. A **changelog** entry documents the root cause and Playwright verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffccae7aa41f48acfe2f5595d388632c092a2181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->