### PR TITLE
fix(djf.io): render blog hero images again

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -42,6 +42,8 @@
     "prettierrc",
     "prettierignore",
     "editorconfig",
-    "prosewrap"
+    "prosewrap",
+    "frontmatter",
+    "shipposting"
   ]
 }

--- a/apps/djf.io/src/layouts/BlogPost.astro
+++ b/apps/djf.io/src/layouts/BlogPost.astro
@@ -41,10 +41,13 @@ const jsonLd = {
         <Image
           src={hero.image.file}
           alt={hero.image.alt}
+          width={400}
+          height={400}
+          densities={[1, 2]}
           loading="eager"
           fetchpriority="high"
           class={css({
-            w: 'full',
+            maxW: 'full',
             h: 'auto',
             borderRadius: 'lg',
             mb: '8',

--- a/apps/djf.io/src/layouts/BlogPost.astro
+++ b/apps/djf.io/src/layouts/BlogPost.astro
@@ -1,4 +1,5 @@
 ---
+import {Image} from 'astro:assets'
 import type {CollectionEntry} from 'astro:content'
 import {css} from 'styled-system/css'
 import BaseLayout from './BaseLayout.astro'
@@ -8,7 +9,7 @@ interface Props {
 }
 
 const {post} = Astro.props
-const {title, description, date, author, tags, readingTime} = post.data
+const {title, description, date, author, tags, readingTime, hero} = post.data
 
 const formattedDate = new Date(date).toLocaleDateString('en-US', {
   year: 'numeric',
@@ -35,6 +36,22 @@ const jsonLd = {
 <BaseLayout title={title} description={description} ogType="article" ogImage={ogImage}>
   <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} slot="head" />
   <article>
+    {
+      hero?.image && (
+        <Image
+          src={hero.image.file}
+          alt={hero.image.alt}
+          loading="eager"
+          fetchpriority="high"
+          class={css({
+            w: 'full',
+            h: 'auto',
+            borderRadius: 'lg',
+            mb: '8',
+          })}
+        />
+      )
+    }
     <header class={css({mb: '8'})}>
       <h1
         class={css({

--- a/apps/djf.io/src/layouts/BlogPost.astro
+++ b/apps/djf.io/src/layouts/BlogPost.astro
@@ -36,73 +36,83 @@ const jsonLd = {
 <BaseLayout title={title} description={description} ogType="article" ogImage={ogImage}>
   <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} slot="head" />
   <article>
-    {
-      hero?.image && (
-        <Image
-          src={hero.image.file}
-          alt={hero.image.alt}
-          width={400}
-          height={400}
-          densities={[1, 2]}
-          loading="eager"
-          fetchpriority="high"
+    <header
+      class={css({
+        mb: '8',
+        display: 'flex',
+        flexDirection: {base: 'column-reverse', md: 'row'},
+        alignItems: {base: 'flex-start', md: 'center'},
+        justifyContent: 'space-between',
+        gap: '6',
+      })}
+    >
+      <div>
+        <h1
           class={css({
-            maxW: 'full',
-            h: 'auto',
-            borderRadius: 'lg',
-            mb: '8',
+            fontSize: '4xl',
+            fontWeight: 'bold',
+            mb: '4',
+            lineHeight: '1.2',
           })}
-        />
-      )
-    }
-    <header class={css({mb: '8'})}>
-      <h1
-        class={css({
-          fontSize: '4xl',
-          fontWeight: 'bold',
-          mb: '4',
-          lineHeight: '1.2',
-        })}
-      >
-        {title}
-      </h1>
+        >
+          {title}
+        </h1>
 
-      <div
-        class={css({
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: '4',
-          color: 'zinc.400',
-          fontSize: 'sm',
-          mb: '4',
-        })}
-      >
-        <span>{formattedDate}</span>
-        {author && <span>by {author}</span>}
-        {readingTime && <span>{readingTime} read</span>}
+        <div
+          class={css({
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '4',
+            color: 'zinc.400',
+            fontSize: 'sm',
+            mb: '4',
+          })}
+        >
+          <span>{formattedDate}</span>
+          {author && <span>by {author}</span>}
+          {readingTime && <span>{readingTime} read</span>}
+        </div>
+
+        {
+          tags && tags.length > 0 && (
+            <div class={css({display: 'flex', flexWrap: 'wrap', gap: '2'})}>
+              {tags.map((tag: string) => (
+                <a
+                  href={`/blog/tags/${tag}`}
+                  class={css({
+                    bg: 'zinc.800',
+                    color: 'zinc.300',
+                    px: '2',
+                    py: '1',
+                    borderRadius: 'md',
+                    fontSize: 'xs',
+                    textDecoration: 'none',
+                    _hover: {bg: 'zinc.700', color: 'zinc.100'},
+                  })}
+                >
+                  {tag}
+                </a>
+              ))}
+            </div>
+          )
+        }
       </div>
 
       {
-        tags && tags.length > 0 && (
-          <div class={css({display: 'flex', flexWrap: 'wrap', gap: '2'})}>
-            {tags.map((tag: string) => (
-              <a
-                href={`/blog/tags/${tag}`}
-                class={css({
-                  bg: 'zinc.800',
-                  color: 'zinc.300',
-                  px: '2',
-                  py: '1',
-                  borderRadius: 'md',
-                  fontSize: 'xs',
-                  textDecoration: 'none',
-                  _hover: {bg: 'zinc.700', color: 'zinc.100'},
-                })}
-              >
-                {tag}
-              </a>
-            ))}
-          </div>
+        hero?.image && (
+          <Image
+            src={hero.image.file}
+            alt={hero.image.alt}
+            width={160}
+            height={160}
+            densities={[1, 2]}
+            loading="eager"
+            fetchpriority="high"
+            class={css({
+              flexShrink: 0,
+              borderRadius: 'lg',
+            })}
+          />
         )
       }
     </header>

--- a/apps/djf.io/src/pages/blog/_[...slug].e2e.test.ts
+++ b/apps/djf.io/src/pages/blog/_[...slug].e2e.test.ts
@@ -17,5 +17,6 @@ test('a blog post with a hero image in frontmatter displays it', async ({page}) 
     name: /animated style illustration a software engineer/,
   })
   await expect(hero).toBeVisible()
-  await expect(hero).toHaveJSProperty('naturalWidth', 1024)
+  const naturalWidth = await hero.evaluate((img) => (img as HTMLImageElement).naturalWidth)
+  expect(naturalWidth).toBeGreaterThan(0)
 })

--- a/apps/djf.io/src/pages/blog/_[...slug].e2e.test.ts
+++ b/apps/djf.io/src/pages/blog/_[...slug].e2e.test.ts
@@ -9,3 +9,13 @@ test('a blog post page renders MDX content and frontmatter', async ({page}) => {
   await expect(page.getByText(/running about four to five times a week/)).toBeVisible()
   await expect(page.getByRole('heading', {level: 2, name: 'Finding your pace'})).toBeVisible()
 })
+
+test('a blog post with a hero image in frontmatter displays it', async ({page}) => {
+  await page.goto('/blog/2023-12-30-shipposting')
+
+  const hero = page.getByRole('img', {
+    name: /animated style illustration a software engineer/,
+  })
+  await expect(hero).toBeVisible()
+  await expect(hero).toHaveJSProperty('naturalWidth', 1024)
+})

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -9,8 +9,9 @@ blog migration: the content schema kept the field and posts still declared it
 (`2023-12-30-shipposting.md` points at `src/assets/shipposting-hero.png`), but
 `BlogPost.astro` never read `hero` from `post.data`, so the image was silently
 dropped. The layout now renders `hero.image` via `astro:assets` `<Image>` above the
-post header -- full column width, rounded corners matching inline images, and
-`loading="eager"` / `fetchpriority="high"` since the hero is the LCP candidate.
+post header -- 400x400 (shrinking on narrower viewports) with a 2x srcset for
+retina, rounded corners matching inline images, and `loading="eager"` /
+`fetchpriority="high"` since the hero is the LCP candidate.
 Posts without a hero image (on-positivity, on-running) are unchanged. Added an e2e
 test asserting the shipposting hero is visible and actually loads
 (`naturalWidth` check).

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -2,6 +2,19 @@
 
 ## 2026-06-10
 
+### fix(djf.io): render blog hero images again
+
+Hero images defined in post frontmatter (`hero.image`) stopped displaying after the
+blog migration: the content schema kept the field and posts still declared it
+(`2023-12-30-shipposting.md` points at `src/assets/shipposting-hero.png`), but
+`BlogPost.astro` never read `hero` from `post.data`, so the image was silently
+dropped. The layout now renders `hero.image` via `astro:assets` `<Image>` above the
+post header -- full column width, rounded corners matching inline images, and
+`loading="eager"` / `fetchpriority="high"` since the hero is the LCP candidate.
+Posts without a hero image (on-positivity, on-running) are unchanged. Added an e2e
+test asserting the shipposting hero is visible and actually loads
+(`naturalWidth` check).
+
 ### feat(djf.io): SEO meta, OG images, sitemap, JSON-LD; Lighthouse 100s
 
 Brought djf.io to production SEO polish and closed out `docs/projects/djf-io-seo/`.

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -8,10 +8,12 @@ Hero images defined in post frontmatter (`hero.image`) stopped displaying after 
 blog migration: the content schema kept the field and posts still declared it
 (`2023-12-30-shipposting.md` points at `src/assets/shipposting-hero.png`), but
 `BlogPost.astro` never read `hero` from `post.data`, so the image was silently
-dropped. The layout now renders `hero.image` via `astro:assets` `<Image>` above the
-post header -- 400x400 (shrinking on narrower viewports) with a 2x srcset for
-retina, rounded corners matching inline images, and `loading="eager"` /
-`fetchpriority="high"` since the hero is the LCP candidate.
+dropped. The layout now renders `hero.image` via `astro:assets` `<Image>` beside
+the post heading -- 160x160 with a 2x srcset for retina, vertically centered
+against the title/meta block on wide screens and stacked above the title on
+narrow ones, mirroring Starlight's old hero placement at a smaller size --
+with rounded corners matching inline images and `loading="eager"` /
+`fetchpriority="high"` since it sits above the fold.
 Posts without a hero image (on-positivity, on-running) are unchanged. Added an e2e
 test asserting the shipposting hero is visible and actually loads
 (`naturalWidth` check).


### PR DESCRIPTION
## Summary

Blog hero images defined in post frontmatter stopped displaying after the migration. The content schema preserved the `hero` field and posts still declare it, but `BlogPost.astro` never extracted `hero` from `post.data`, causing images to be silently dropped. This fix restores hero image rendering.

## Changes

- Import `Image` from `astro:assets` in `BlogPost.astro`
- Extract `hero` field from post frontmatter data
- Restructure header layout to display hero image (160×160) beside the title/metadata block
  - Flex layout with `flex-direction: column-reverse` on mobile (image stacks above title)
  - `flex-direction: row` on desktop (image sits to the right, vertically centered)
- Render hero image with `astro:assets` `<Image>` component with:
  - 2× srcset for retina displays (`densities={[1, 2]}`)
  - `loading="eager"` and `fetchpriority="high"` (above the fold)
  - Rounded corners matching inline images
- Add e2e test verifying hero image visibility and successful load (via `naturalWidth` check)
- Update cspell config to recognize "frontmatter" and "shipposting"

## Changelog entry

```markdown
### fix(djf.io): render blog hero images again

Hero images defined in post frontmatter (`hero.image`) stopped displaying after the
blog migration: the content schema kept the field and posts still declared it
(`2023-12-30-shipposting.md` points at `src/assets/shipposting-hero.png`), but
`BlogPost.astro` never read `hero` from `post.data`, so the image was silently
dropped. The layout now renders `hero.image` via `astro:assets` `<Image>` beside
the post heading — 160×160 with a 2× srcset for retina, vertically centered
against the title/meta block on wide screens and stacked above the title on
narrow ones, mirroring Starlight's old hero placement at a smaller size —
with rounded corners matching inline images and `loading="eager"` /
`fetchpriority="high"` since it sits above the fold.
Posts without a hero image (on-positivity, on-running) are unchanged. Added an e2e
test asserting the shipposting hero is visible and actually loads
(`naturalWidth` check).
```

## Testing

- [x] E2E test added verifying hero image renders and loads for posts with `hero.image` defined
- [x] Posts without hero images remain unchanged
- [x] Builds successfully

https://claude.ai/code/session_01FfXG41QEFoFbYpmyGzD4wZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only blog layout change with optional frontmatter; covered by a new e2e test.
> 
> **Overview**
> Restores **blog hero images** from frontmatter (`hero.image`) that were dropped after migration: `BlogPost.astro` now reads `hero` from `post.data` and renders it with `astro:assets` `<Image>` (160×160, 2× density, eager/high priority).
> 
> The post header is a **responsive flex layout**—title/meta/tags on one side, optional hero on the other (stacked above the title on small screens). Posts without `hero.image` behave as before.
> 
> Adds a Playwright e2e on the shipposting post (visibility + `naturalWidth`), cspell entries for **frontmatter** / **shipposting**, and a changelog note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c322dda8fcb7799597baeb8284c6a71ddb8c2e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->