### PR TITLE
fix(f311x): restore prod — ingress, deploy pipeline, artifact

### DIFF
--- a/.github/workflows/cd-deploy-f311x.yml
+++ b/.github/workflows/cd-deploy-f311x.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'apps/f311x/**'
       - '.github/workflows/cd-deploy-f311x.yml'
+  workflow_dispatch:
 
 defaults:
   run:

--- a/apps/f311x/alchemy.run.ts
+++ b/apps/f311x/alchemy.run.ts
@@ -22,6 +22,10 @@ export const Website = Cloudflare.Vite('Website', {
     date: '2026-05-01',
     flags: ['nodejs_compat'],
   },
+  // Custom domains are the Worker's only ingress: Alchemy attaches them on
+  // deploy and Cloudflare materializes the DNS records. The f311x.com zone
+  // must already exist in this account.
+  domain: ['f311x.com', 'www.f311x.com'],
 })
 
 export default Alchemy.Stack(

--- a/apps/f311x/package.json
+++ b/apps/f311x/package.json
@@ -66,16 +66,5 @@
     "vite": "8.0.16",
     "vitest": "4.1.8",
     "wrangler": "4.98.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "@distilled.cloud/aws": "0.24.8",
-      "@distilled.cloud/axiom": "0.24.8",
-      "@distilled.cloud/cloudflare": "0.24.8",
-      "@distilled.cloud/core": "0.24.8",
-      "@distilled.cloud/neon": "0.24.8",
-      "@distilled.cloud/planetscale": "0.24.8",
-      "@effect/platform-node-shared": "4.0.0-beta.78"
-    }
   }
 }

--- a/apps/f311x/package.json
+++ b/apps/f311x/package.json
@@ -32,7 +32,7 @@
     "@tanstack/react-router-devtools": "latest",
     "@tanstack/react-start": "latest",
     "@tanstack/router-plugin": "^1.168.11",
-    "alchemy": "2.0.0-beta.51",
+    "alchemy": "2.0.0-beta.55",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "effect": "4.0.0-beta.78",
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20260605.1",
+    "@effect/platform-node": "4.0.0-beta.78",
     "@tailwindcss/typography": "0.5.19",
     "@tanstack/devtools-vite": "latest",
     "@testing-library/dom": "10.4.1",

--- a/apps/f311x/package.json
+++ b/apps/f311x/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.38.0",
-    "@distilled.cloud/cloudflare": "0.23.1",
     "@fontsource-variable/geist": "^5.2.9",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/ai": "^0.28.0",
@@ -32,7 +31,7 @@
     "@tanstack/react-router-devtools": "latest",
     "@tanstack/react-start": "latest",
     "@tanstack/router-plugin": "^1.168.11",
-    "alchemy": "2.0.0-beta.55",
+    "alchemy": "2.0.0-beta.54",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "effect": "4.0.0-beta.78",
@@ -67,5 +66,16 @@
     "vite": "8.0.16",
     "vitest": "4.1.8",
     "wrangler": "4.98.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "@distilled.cloud/aws": "0.24.8",
+      "@distilled.cloud/axiom": "0.24.8",
+      "@distilled.cloud/cloudflare": "0.24.8",
+      "@distilled.cloud/core": "0.24.8",
+      "@distilled.cloud/neon": "0.24.8",
+      "@distilled.cloud/planetscale": "0.24.8",
+      "@effect/platform-node-shared": "4.0.0-beta.78"
+    }
   }
 }

--- a/apps/f311x/pnpm-lock.yaml
+++ b/apps/f311x/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@distilled.cloud/aws': 0.24.8
+  '@distilled.cloud/axiom': 0.24.8
+  '@distilled.cloud/cloudflare': 0.24.8
+  '@distilled.cloud/core': 0.24.8
+  '@distilled.cloud/neon': 0.24.8
+  '@distilled.cloud/planetscale': 0.24.8
+  '@effect/platform-node-shared': 4.0.0-beta.78
+
 importers:
 
   .:
@@ -11,9 +20,6 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.38.0
         version: 1.40.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)(wrangler@4.98.0(@cloudflare/workers-types@4.20260605.1))
-      '@distilled.cloud/cloudflare':
-        specifier: 0.23.1
-        version: 0.23.1(effect@4.0.0-beta.78)
       '@fontsource-variable/geist':
         specifier: ^5.2.9
         version: 5.2.9
@@ -42,8 +48,8 @@ importers:
         specifier: ^1.168.11
         version: 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
       alchemy:
-        specifier: 2.0.0-beta.55
-        version: 2.0.0-beta.55(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(@types/node@25.9.1)(@types/react@19.2.16)(effect@4.0.0-beta.78)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260603.1)(ws@8.21.0)
+        specifier: 2.0.0-beta.54
+        version: 2.0.0-beta.54(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(@types/node@25.9.1)(@types/react@19.2.16)(effect@4.0.0-beta.78)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260603.1)(ws@8.21.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -532,13 +538,13 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@distilled.cloud/aws@0.24.9':
-    resolution: {integrity: sha512-VTW9AqBszccrobGCrJfzM3SUmQ7DP2y7ez9Zxm0rzZk/sK5UiuGszl5GNmbUoJos7Bbd3E6JZv0nF88R/ZLiMg==}
+  '@distilled.cloud/aws@0.24.8':
+    resolution: {integrity: sha512-wukMIR1tJCxWeEXPpAZn+jhuLXICKwSc4racRsgIn/oCoQZunLU7P7BilvXobsbdkYds5Q7vzsTtcIhSdb/wEg==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/axiom@0.24.9':
-    resolution: {integrity: sha512-PHu0euPZ7ewzTDhGrDIXMf9h59V1MQABB5OaXjQlQdN6eJuBHC74RejoVHuE3RVbFW9f77/6Ua/PMndzJwvwww==}
+  '@distilled.cloud/axiom@0.24.8':
+    resolution: {integrity: sha512-o8U4oYpAVoZzC+AAKOv+D6Oauq4x45cRfzD1VScjQdYK4OB57we4NFMzNnuRTyp29HKDveFE1d2IenFkICAx5Q==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
@@ -556,7 +562,7 @@ packages:
   '@distilled.cloud/cloudflare-runtime@0.10.12':
     resolution: {integrity: sha512-nKzvN+UU4EaAtUHncMxblSCtaaL+HRlX1wt/PC/Nwi+njhnEi5TOYqkVfT2ULlO7YwLGOduSGyEFwBuxaNCELw==}
     peerDependencies:
-      '@distilled.cloud/cloudflare': ^0.24.5
+      '@distilled.cloud/cloudflare': 0.24.8
       '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
       '@effect/platform-node': '>=4.0.0-beta.78 || >=4.0.0'
       effect: '>=4.0.0-beta.78 || >=4.0.0'
@@ -569,7 +575,7 @@ packages:
   '@distilled.cloud/cloudflare-vite-plugin@0.10.12':
     resolution: {integrity: sha512-SpkV81YBvZv8p1G+7ghft0ZJPqeS5wII79hAzueCtMlDMfWZKrljZOpqXT5QUGCVg98LKtv2DjirB0CBHSWdcw==}
     peerDependencies:
-      '@distilled.cloud/cloudflare': ^0.24.5
+      '@distilled.cloud/cloudflare': 0.24.8
       '@distilled.cloud/cloudflare-runtime': 0.10.12
       '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
       '@effect/platform-node': '>=4.0.0-beta.78 || >=4.0.0'
@@ -581,33 +587,23 @@ packages:
       '@effect/platform-node':
         optional: true
 
-  '@distilled.cloud/cloudflare@0.23.1':
-    resolution: {integrity: sha512-/OKikqtYpn1SQUlgEvHO3Y32VskQPql6x575anfLCcanCcU9ufj+Lz7ZNKxYL85ZQCvuPD3gbZ8areVvWPcU6A==}
+  '@distilled.cloud/cloudflare@0.24.8':
+    resolution: {integrity: sha512-je0KN9qCITUpHGViq0jrNM1hC/w3czbgaaYPObiHXPrjSfSXSsR0PuQvArfZTxtQLLzZ9FhdraCnbO75A6eDfA==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/cloudflare@0.24.9':
-    resolution: {integrity: sha512-Y+1sQcPtVAKDrSo48j9Ip30v1JIu3KcIBzflml5hQGEVamXxbHqToNDhE8IKnrN/QRlTZEHKHG8eplRwZ+qSfQ==}
+  '@distilled.cloud/core@0.24.8':
+    resolution: {integrity: sha512-GwC8OrGnHUortLSbbeLEfVk6R+ud+wcCK2DH8Uas3Q+gRa0+/ufXwZfAsXSAnuYoEGrj0DXL6P1kCDTPK0f6dw==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/core@0.23.1':
-    resolution: {integrity: sha512-WQNSiPfiXuHeaQteSK5HgEiHjxdIPtOgE+YOugU56Eio1/EkSH84Q/FDqi5StJ0MVyhN9kjzO0lWwZL2//ZeHA==}
+  '@distilled.cloud/neon@0.24.8':
+    resolution: {integrity: sha512-se3pVc9peuGnN1U5HMt9HVoGFg/hwxWPOpD6y+5uezs0eS11359yFGRbmCvidYV1zOURvdjr5DGUWm+zjxOLQQ==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/core@0.24.9':
-    resolution: {integrity: sha512-0RXv01StS6/yof8ugdaj7PPtaHx6geTY6hH7oZ9f1yfg+8Lqs/b2GE7v4VKyW6A2XnMlMVH8vodeUgbnPmyBUA==}
-    peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
-
-  '@distilled.cloud/neon@0.24.9':
-    resolution: {integrity: sha512-kP+9fLkGf7QOXM6hl896qjw8EefD9PWJ0JyH+x+kBhxGUErd83BDNqUvhYDrnANYlfWcT/Q5qi9xNhbBUSxncQ==}
-    peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
-
-  '@distilled.cloud/planetscale@0.24.9':
-    resolution: {integrity: sha512-XU2/mCGGKqek/xlOW5OssBccNTkPRkpteLgVzHT7qBSkQPCaojwUo+pxA9usKqcbGJr/6ZYUJRGFoUy/4jcm/A==}
+  '@distilled.cloud/planetscale@0.24.8':
+    resolution: {integrity: sha512-7rZjN5RZRSoh+utGa2VAdvo5f3AHjelk+ekv7jnqVNc6p8hFOpS+BRZ00QWb+444Y2AVOwqO0uIoBBmxVqhrfA==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
@@ -621,11 +617,11 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
-  '@effect/platform-node-shared@4.0.0-beta.80':
-    resolution: {integrity: sha512-VY+p9cgD20T/Qot/390wbaBYx1ngE5bC8PbyIsHmjKRcnOVO/774wxn528GEfRMOQtLc5zh1stcQOp/GlXNF6Q==}
+  '@effect/platform-node-shared@4.0.0-beta.78':
+    resolution: {integrity: sha512-mo0ddTPATyCMyqzQasYDL7+NI29vozoMplom+qu9f/onDTd4xG5hvEEfGxfL0Ljygui6keG/YE/E9OZVf2z5WA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.80
+      effect: ^4.0.0-beta.78
 
   '@effect/platform-node@4.0.0-beta.78':
     resolution: {integrity: sha512-8ONrIS5/R9dq+0BJ6v3kUXNEkfjU6S3GzIYCH5gmHdiriRvIoBhXYNAITfRvZpfx1JPrKuP70cHyuQDjmJcDkQ==}
@@ -2903,8 +2899,8 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  alchemy@2.0.0-beta.55:
-    resolution: {integrity: sha512-Pn/2stqBXBoEyFqZ0/QuEFw3okm9lksXARHKhTkwDdl7qwTpyTLsLJJk6YWEnhov95OO/iDEf03AiCsh2+WCnw==}
+  alchemy@2.0.0-beta.54:
+    resolution: {integrity: sha512-4FN+Bz4t/ssZVz1pf5ZNidn5ifYLorZBSRJ0nGPO2qJ3x1xkQdGoNQDP82pMjgihWe3eN9rFI26b8n6EPjjwkg==}
     hasBin: true
     peerDependencies:
       '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
@@ -5898,13 +5894,13 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@distilled.cloud/aws@0.24.9(effect@4.0.0-beta.78)':
+  '@distilled.cloud/aws@0.24.8(effect@4.0.0-beta.78)':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1063.0
       '@aws-sdk/types': 3.973.11
-      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/core': 0.24.8(effect@4.0.0-beta.78)
       '@smithy/shared-ini-file-loader': 4.5.6
       '@smithy/types': 4.14.3
       '@smithy/util-base64': 4.4.6
@@ -5912,9 +5908,9 @@ snapshots:
       effect: 4.0.0-beta.78
       fast-xml-parser: 5.8.0
 
-  '@distilled.cloud/axiom@0.24.9(effect@4.0.0-beta.78)':
+  '@distilled.cloud/axiom@0.24.8(effect@4.0.0-beta.78)':
     dependencies:
-      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/core': 0.24.8(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
 
   '@distilled.cloud/cloudflare-rolldown-plugin@0.10.12(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)':
@@ -5928,20 +5924,20 @@ snapshots:
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.10.12(@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)':
+  '@distilled.cloud/cloudflare-runtime@0.10.12(@distilled.cloud/cloudflare@0.24.8(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)':
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
-      '@distilled.cloud/cloudflare': 0.23.1(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare': 0.24.8(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
       workerd: 1.20260526.1
     optionalDependencies:
       '@effect/platform-node': 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.10.12(@distilled.cloud/cloudflare-runtime@0.10.12(@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.10.12(@distilled.cloud/cloudflare-runtime@0.10.12(@distilled.cloud/cloudflare@0.24.8(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.24.8(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare': 0.24.8(effect@4.0.0-beta.78)
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.10.12(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)
-      '@distilled.cloud/cloudflare-runtime': 0.10.12(@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare-runtime': 0.10.12(@distilled.cloud/cloudflare@0.24.8(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
@@ -5950,32 +5946,23 @@ snapshots:
       - rolldown
       - workerd
 
-  '@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78)':
+  '@distilled.cloud/cloudflare@0.24.8(effect@4.0.0-beta.78)':
     dependencies:
-      '@distilled.cloud/core': 0.23.1(effect@4.0.0-beta.78)
+      '@distilled.cloud/core': 0.24.8(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
 
-  '@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78)':
-    dependencies:
-      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
-
-  '@distilled.cloud/core@0.23.1(effect@4.0.0-beta.78)':
+  '@distilled.cloud/core@0.24.8(effect@4.0.0-beta.78)':
     dependencies:
       effect: 4.0.0-beta.78
 
-  '@distilled.cloud/core@0.24.9(effect@4.0.0-beta.78)':
+  '@distilled.cloud/neon@0.24.8(effect@4.0.0-beta.78)':
     dependencies:
+      '@distilled.cloud/core': 0.24.8(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
 
-  '@distilled.cloud/neon@0.24.9(effect@4.0.0-beta.78)':
+  '@distilled.cloud/planetscale@0.24.8(effect@4.0.0-beta.78)':
     dependencies:
-      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
-
-  '@distilled.cloud/planetscale@0.24.9(effect@4.0.0-beta.78)':
-    dependencies:
-      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/core': 0.24.8(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
 
   '@dotenvx/dotenvx@1.71.0':
@@ -5996,7 +5983,7 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
-  '@effect/platform-node-shared@4.0.0-beta.80(effect@4.0.0-beta.78)':
+  '@effect/platform-node-shared@4.0.0-beta.78(effect@4.0.0-beta.78)':
     dependencies:
       '@types/ws': 8.18.1
       effect: 4.0.0-beta.78
@@ -6007,7 +5994,7 @@ snapshots:
 
   '@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.80(effect@4.0.0-beta.78)
+      '@effect/platform-node-shared': 4.0.0-beta.78(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
       ioredis: 5.11.1
       mime: 4.1.0
@@ -8121,20 +8108,20 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alchemy@2.0.0-beta.55(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(@types/node@25.9.1)(@types/react@19.2.16)(effect@4.0.0-beta.78)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260603.1)(ws@8.21.0):
+  alchemy@2.0.0-beta.54(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(@types/node@25.9.1)(@types/react@19.2.16)(effect@4.0.0-beta.78)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260603.1)(ws@8.21.0):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1063.0
       '@clack/prompts': 0.11.0
-      '@distilled.cloud/aws': 0.24.9(effect@4.0.0-beta.78)
-      '@distilled.cloud/axiom': 0.24.9(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/aws': 0.24.8(effect@4.0.0-beta.78)
+      '@distilled.cloud/axiom': 0.24.8(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare': 0.24.8(effect@4.0.0-beta.78)
       '@distilled.cloud/cloudflare-rolldown-plugin': 0.10.12(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)
-      '@distilled.cloud/cloudflare-runtime': 0.10.12(@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare-vite-plugin': 0.10.12(@distilled.cloud/cloudflare-runtime@0.10.12(@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)
-      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
-      '@distilled.cloud/neon': 0.24.9(effect@4.0.0-beta.78)
-      '@distilled.cloud/planetscale': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare-runtime': 0.10.12(@distilled.cloud/cloudflare@0.24.8(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare-vite-plugin': 0.10.12(@distilled.cloud/cloudflare-runtime@0.10.12(@distilled.cloud/cloudflare@0.24.8(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.24.8(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)
+      '@distilled.cloud/core': 0.24.8(effect@4.0.0-beta.78)
+      '@distilled.cloud/neon': 0.24.8(effect@4.0.0-beta.78)
+      '@distilled.cloud/planetscale': 0.24.8(effect@4.0.0-beta.78)
       '@effect/vitest': 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.3
       '@octokit/rest': 22.0.1

--- a/apps/f311x/pnpm-lock.yaml
+++ b/apps/f311x/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^1.168.11
         version: 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
       alchemy:
-        specifier: 2.0.0-beta.51
-        version: 2.0.0-beta.51(@types/node@25.9.1)(@types/react@19.2.16)(effect@4.0.0-beta.78)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260603.1)(ws@8.21.0)
+        specifier: 2.0.0-beta.55
+        version: 2.0.0-beta.55(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(@types/node@25.9.1)(@types/react@19.2.16)(effect@4.0.0-beta.78)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260603.1)(ws@8.21.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -99,6 +99,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 4.20260605.1
         version: 4.20260605.1
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.78
+        version: 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1)
       '@tailwindcss/typography':
         specifier: 0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
@@ -148,8 +151,8 @@ packages:
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
     engines: {node: '>=18'}
 
-  '@alchemy.run/node-utils@0.0.4':
-    resolution: {integrity: sha512-TiIhPXCTCi3tk0zmdYJJ14CNSesSfsJxXdIOP0HTSItQ1mZWLocrF7qCuEWKyW/IEFzp6kaiOf19aIA/mbCp1g==}
+  '@alchemy.run/node-utils@0.0.5':
+    resolution: {integrity: sha512-5agdhQxWBodxa5hDRyjnpx91RTU3g+qd5fxYB7uNDCaOzB0XC47UU/KHR6zf6jhz/NXf61gJS+vhYwn8NHeRoQ==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -529,45 +532,48 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@distilled.cloud/aws@0.22.4':
-    resolution: {integrity: sha512-qa+MnIdlRy6QmXuRwGqBNQnF2mu9MyUck2yeYkEesDpOH4eJFcjZy8nVUIhWxACfSIMvLd59FD6bkdVALzI5Dg==}
+  '@distilled.cloud/aws@0.24.9':
+    resolution: {integrity: sha512-VTW9AqBszccrobGCrJfzM3SUmQ7DP2y7ez9Zxm0rzZk/sK5UiuGszl5GNmbUoJos7Bbd3E6JZv0nF88R/ZLiMg==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/axiom@0.22.4':
-    resolution: {integrity: sha512-CcSe8UPEPLGW/tGZ/ky5Hn5Gfd2/43bn5km6opeiyN45HrHbkvYURQeiqgcivJt2Y01Mh0lMeBkQQdfCjJIhjA==}
+  '@distilled.cloud/axiom@0.24.9':
+    resolution: {integrity: sha512-PHu0euPZ7ewzTDhGrDIXMf9h59V1MQABB5OaXjQlQdN6eJuBHC74RejoVHuE3RVbFW9f77/6Ua/PMndzJwvwww==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/cloudflare-rolldown-plugin@0.10.2':
-    resolution: {integrity: sha512-N7YbH8t4B53qxzJO/AkQZ3xuJ7NHM0vfQj5cju1DxNt+JNfD9MRbgswwWnsB+pr2n+/lQvol1NezJPaPFtYFiQ==}
+  '@distilled.cloud/cloudflare-rolldown-plugin@0.10.12':
+    resolution: {integrity: sha512-qHLL5DqQdY4LIVtcdqKSzpINGT+xczJ8rfRfK32lOburW3h6IDtUph4HjAQsP1FJypVNQiThAJmfnpbI0SaYVg==}
     peerDependencies:
       rolldown: ^1.0.1
+      vite: ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       rolldown:
         optional: true
+      vite:
+        optional: true
 
-  '@distilled.cloud/cloudflare-runtime@0.10.2':
-    resolution: {integrity: sha512-0bcaKDYFAeqKSjUx7a3hUPjhFxTag2iKWpQxZUKSG9MYs6KmM2Ycdd95C70+QEp5KXQ4hpwZ46jUpfldQlu/fQ==}
+  '@distilled.cloud/cloudflare-runtime@0.10.12':
+    resolution: {integrity: sha512-nKzvN+UU4EaAtUHncMxblSCtaaL+HRlX1wt/PC/Nwi+njhnEi5TOYqkVfT2ULlO7YwLGOduSGyEFwBuxaNCELw==}
     peerDependencies:
-      '@distilled.cloud/cloudflare': ^0.22.0
-      '@effect/platform-bun': '>=4.0.0-beta.66 || >=4.0.0'
-      '@effect/platform-node': '>=4.0.0-beta.66 || >=4.0.0'
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
+      '@distilled.cloud/cloudflare': ^0.24.5
+      '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
+      '@effect/platform-node': '>=4.0.0-beta.78 || >=4.0.0'
+      effect: '>=4.0.0-beta.78 || >=4.0.0'
     peerDependenciesMeta:
       '@effect/platform-bun':
         optional: true
       '@effect/platform-node':
         optional: true
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.10.2':
-    resolution: {integrity: sha512-80bjDi+NrRLfqYLqIHAbzFZd1SUkbvHIEcaG+If/0X+rMDNKhdIuVl/vuk09N6BG/dJ7meyCj+QG/4ua3u5YOg==}
+  '@distilled.cloud/cloudflare-vite-plugin@0.10.12':
+    resolution: {integrity: sha512-SpkV81YBvZv8p1G+7ghft0ZJPqeS5wII79hAzueCtMlDMfWZKrljZOpqXT5QUGCVg98LKtv2DjirB0CBHSWdcw==}
     peerDependencies:
-      '@distilled.cloud/cloudflare': ^0.22.0
-      '@distilled.cloud/cloudflare-runtime': 0.10.2
-      '@effect/platform-bun': '>=4.0.0-beta.66 || >=4.0.0'
-      '@effect/platform-node': '>=4.0.0-beta.66 || >=4.0.0'
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
+      '@distilled.cloud/cloudflare': ^0.24.5
+      '@distilled.cloud/cloudflare-runtime': 0.10.12
+      '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
+      '@effect/platform-node': '>=4.0.0-beta.78 || >=4.0.0'
+      effect: '>=4.0.0-beta.78 || >=4.0.0'
       vite: ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@effect/platform-bun':
@@ -575,18 +581,13 @@ packages:
       '@effect/platform-node':
         optional: true
 
-  '@distilled.cloud/cloudflare@0.22.4':
-    resolution: {integrity: sha512-hDqVoGmJlPoGCgurVFbk399gkPyu9Pr/w8D4Rv/q5twaK29Ioy5NGk2oLJrfKwaKZVeBDl7TzIxVX0wW3HQlCA==}
-    peerDependencies:
-      effect: '>=4.0.0-beta.66 || >=4.0.0'
-
   '@distilled.cloud/cloudflare@0.23.1':
     resolution: {integrity: sha512-/OKikqtYpn1SQUlgEvHO3Y32VskQPql6x575anfLCcanCcU9ufj+Lz7ZNKxYL85ZQCvuPD3gbZ8areVvWPcU6A==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/core@0.22.4':
-    resolution: {integrity: sha512-OuyM6cfOzQO0+n05Mb8jHDNrFxBjw27Q+9KL/uWRknLfTa3B1KDzyYJlt14MOFubl4YywreteNxGzcoGNhFN2A==}
+  '@distilled.cloud/cloudflare@0.24.9':
+    resolution: {integrity: sha512-Y+1sQcPtVAKDrSo48j9Ip30v1JIu3KcIBzflml5hQGEVamXxbHqToNDhE8IKnrN/QRlTZEHKHG8eplRwZ+qSfQ==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
@@ -595,13 +596,18 @@ packages:
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/neon@0.22.4':
-    resolution: {integrity: sha512-dE6h0mNTi5CUalMLcXgJmolYeCakB9bYCUHo1w/ERzwbb9MsyKLYckvRQbK1mcwKmrBdzZJWC1kaG8ZfNYDfTg==}
+  '@distilled.cloud/core@0.24.9':
+    resolution: {integrity: sha512-0RXv01StS6/yof8ugdaj7PPtaHx6geTY6hH7oZ9f1yfg+8Lqs/b2GE7v4VKyW6A2XnMlMVH8vodeUgbnPmyBUA==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
-  '@distilled.cloud/planetscale@0.22.4':
-    resolution: {integrity: sha512-SrMlYTnKBtZ0p6Sug4RzsSHRUPxJtjHLUmANI7q1SGDPoWZLCCfRuDdVTFBVi9WBjxlmJtDDjpHCQoEwA8qeLQ==}
+  '@distilled.cloud/neon@0.24.9':
+    resolution: {integrity: sha512-kP+9fLkGf7QOXM6hl896qjw8EefD9PWJ0JyH+x+kBhxGUErd83BDNqUvhYDrnANYlfWcT/Q5qi9xNhbBUSxncQ==}
+    peerDependencies:
+      effect: '>=4.0.0-beta.66 || >=4.0.0'
+
+  '@distilled.cloud/planetscale@0.24.9':
+    resolution: {integrity: sha512-XU2/mCGGKqek/xlOW5OssBccNTkPRkpteLgVzHT7qBSkQPCaojwUo+pxA9usKqcbGJr/6ZYUJRGFoUy/4jcm/A==}
     peerDependencies:
       effect: '>=4.0.0-beta.66 || >=4.0.0'
 
@@ -614,6 +620,19 @@ packages:
     engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
     peerDependencies:
       '@noble/ciphers': ^1.0.0
+
+  '@effect/platform-node-shared@4.0.0-beta.80':
+    resolution: {integrity: sha512-VY+p9cgD20T/Qot/390wbaBYx1ngE5bC8PbyIsHmjKRcnOVO/774wxn528GEfRMOQtLc5zh1stcQOp/GlXNF6Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-beta.80
+
+  '@effect/platform-node@4.0.0-beta.78':
+    resolution: {integrity: sha512-8ONrIS5/R9dq+0BJ6v3kUXNEkfjU6S3GzIYCH5gmHdiriRvIoBhXYNAITfRvZpfx1JPrKuP70cHyuQDjmJcDkQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-beta.78
+      ioredis: ^5.7.0
 
   '@effect/vitest@4.0.0-beta.78':
     resolution: {integrity: sha512-5KQsQYrQ/o7mfOVAxRtNnfD9M0W4OI6yQd0n/m2N7OOLxTdX4FwN4s/X4obykBC7ZEwH+bzMrFJiB4pq9lrQKQ==}
@@ -1006,6 +1025,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2881,16 +2903,16 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  alchemy@2.0.0-beta.51:
-    resolution: {integrity: sha512-hCdHtOI2xVPRLAQV3tQfPQREaTsark3EOzrvij+vqsxwwykCvSFxe6aCU/icgTaDE7fiazC38Tniy6zQKGrqXg==}
+  alchemy@2.0.0-beta.55:
+    resolution: {integrity: sha512-Pn/2stqBXBoEyFqZ0/QuEFw3okm9lksXARHKhTkwDdl7qwTpyTLsLJJk6YWEnhov95OO/iDEf03AiCsh2+WCnw==}
     hasBin: true
     peerDependencies:
-      '@effect/platform-bun': '>=4.0.0-beta.74 || >=4.0.0'
-      '@effect/platform-node': '>=4.0.0-beta.74 || >=4.0.0'
-      '@effect/sql-pg': '>=4.0.0-beta.74 || >=4.0.0'
+      '@effect/platform-bun': '>=4.0.0-beta.78 || >=4.0.0'
+      '@effect/platform-node': '>=4.0.0-beta.78 || >=4.0.0'
+      '@effect/sql-pg': '>=4.0.0-beta.78 || >=4.0.0'
       drizzle-kit: '>=1.0.0-rc.1'
       drizzle-orm: '>=1.0.0-rc.1'
-      effect: '>=4.0.0-beta.74 || >=4.0.0'
+      effect: '>=4.0.0-beta.78 || >=4.0.0'
       vite: ^8.0.7
       ws: ^8.20.0
     peerDependenciesMeta:
@@ -3040,9 +3062,6 @@ packages:
   capnweb@0.6.1:
     resolution: {integrity: sha512-fmhV26QPd1ewf5R74h55oVZnGwIcSaRMzbfLQUy8+zOBjuTmT3KXoT8wxHvnp1m9Ht9BoUUS5ZwNLoVLfQTyBg==}
 
-  capnweb@0.7.0:
-    resolution: {integrity: sha512-zO7tt5ch2tImacaR/oMd7e1dqi/fWU7hjZdvQMv6Yo3v9uUGA8cPIUQGvfQTu2c+NgyE/j/oDmMaUlf1PXyfJw==}
-
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -3065,10 +3084,6 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
-
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -3108,6 +3123,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -3679,6 +3698,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -4169,6 +4192,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@4.1.0:
+    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -4298,10 +4326,6 @@ packages:
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
-
-  os-paths@7.4.0:
-    resolution: {integrity: sha512-Ux1J4NUqC6tZayBqLN1kUlDAEvLiQlli/53sSddU4IN+h+3xxnv2HmRSMpVSvr1hvJzotfMs3ERvETGK+f4OwA==}
-    engines: {node: '>= 4.0'}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -4569,10 +4593,6 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
-
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -4580,6 +4600,14 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
 
   remark-breaks@4.0.0:
     resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
@@ -4787,6 +4815,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -4962,6 +4993,10 @@ packages:
   undici@7.27.2:
     resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.4.1:
+    resolution: {integrity: sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==}
+    engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -5256,14 +5291,6 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
-  xdg-app-paths@8.3.0:
-    resolution: {integrity: sha512-mgxlWVZw0TNWHoGmXq+NC3uhCIc55dDpAlDkMQUaIAcQzysb0kxctwv//fvuW61/nAAeUBJMQ8mnZjMmuYwOcQ==}
-    engines: {node: '>= 4.0'}
-
-  xdg-portable@10.6.0:
-    resolution: {integrity: sha512-xrcqhWDvtZ7WLmt8G4f3hHy37iK7D2idtosRgkeiSPZEPmBShp0VfmRBLWAPC6zLF48APJ21yfea+RfQMF4/Aw==}
-    engines: {node: '>= 4.0'}
-
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -5345,7 +5372,7 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  '@alchemy.run/node-utils@0.0.4': {}
+  '@alchemy.run/node-utils@0.0.5': {}
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -5871,13 +5898,13 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@distilled.cloud/aws@0.22.4(effect@4.0.0-beta.78)':
+  '@distilled.cloud/aws@0.24.9(effect@4.0.0-beta.78)':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/credential-providers': 3.1063.0
       '@aws-sdk/types': 3.973.11
-      '@distilled.cloud/core': 0.22.4(effect@4.0.0-beta.78)
+      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
       '@smithy/shared-ini-file-loader': 4.5.6
       '@smithy/types': 4.14.3
       '@smithy/util-base64': 4.4.6
@@ -5885,68 +5912,70 @@ snapshots:
       effect: 4.0.0-beta.78
       fast-xml-parser: 5.8.0
 
-  '@distilled.cloud/axiom@0.22.4(effect@4.0.0-beta.78)':
+  '@distilled.cloud/axiom@0.24.9(effect@4.0.0-beta.78)':
     dependencies:
-      '@distilled.cloud/core': 0.22.4(effect@4.0.0-beta.78)
+      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
 
-  '@distilled.cloud/cloudflare-rolldown-plugin@0.10.2(rolldown@1.0.1)(workerd@1.20260603.1)':
+  '@distilled.cloud/cloudflare-rolldown-plugin@0.10.12(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260603.1)
       magic-string: 0.30.21
       unenv: 2.0.0-rc.24
     optionalDependencies:
       rolldown: 1.0.1
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - workerd
 
-  '@distilled.cloud/cloudflare-runtime@0.10.2(@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78))(effect@4.0.0-beta.78)':
+  '@distilled.cloud/cloudflare-runtime@0.10.12(@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)':
     dependencies:
-      '@alchemy.run/node-utils': 0.0.4
+      '@alchemy.run/node-utils': 0.0.5
       '@distilled.cloud/cloudflare': 0.23.1(effect@4.0.0-beta.78)
-      capnweb: 0.7.0
-      chokidar: 4.0.3
       effect: 4.0.0-beta.78
       workerd: 1.20260526.1
-      xdg-app-paths: 8.3.0
+    optionalDependencies:
+      '@effect/platform-node': 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1)
 
-  '@distilled.cloud/cloudflare-vite-plugin@0.10.2(@distilled.cloud/cloudflare-runtime@0.10.2(@distilled.cloud/cloudflare@0.22.4(effect@4.0.0-beta.78))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.22.4(effect@4.0.0-beta.78))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)':
+  '@distilled.cloud/cloudflare-vite-plugin@0.10.12(@distilled.cloud/cloudflare-runtime@0.10.12(@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)':
     dependencies:
-      '@distilled.cloud/cloudflare': 0.22.4(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.10.2(rolldown@1.0.1)(workerd@1.20260603.1)
-      '@distilled.cloud/cloudflare-runtime': 0.10.2(@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78))(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.10.12(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)
+      '@distilled.cloud/cloudflare-runtime': 0.10.12(@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)
+    optionalDependencies:
+      '@effect/platform-node': 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1)
     transitivePeerDependencies:
       - rolldown
       - workerd
-
-  '@distilled.cloud/cloudflare@0.22.4(effect@4.0.0-beta.78)':
-    dependencies:
-      '@distilled.cloud/core': 0.22.4(effect@4.0.0-beta.78)
-      effect: 4.0.0-beta.78
 
   '@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78)':
     dependencies:
       '@distilled.cloud/core': 0.23.1(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
 
-  '@distilled.cloud/core@0.22.4(effect@4.0.0-beta.78)':
+  '@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78)':
     dependencies:
+      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
 
   '@distilled.cloud/core@0.23.1(effect@4.0.0-beta.78)':
     dependencies:
       effect: 4.0.0-beta.78
 
-  '@distilled.cloud/neon@0.22.4(effect@4.0.0-beta.78)':
+  '@distilled.cloud/core@0.24.9(effect@4.0.0-beta.78)':
     dependencies:
-      '@distilled.cloud/core': 0.22.4(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
 
-  '@distilled.cloud/planetscale@0.22.4(effect@4.0.0-beta.78)':
+  '@distilled.cloud/neon@0.24.9(effect@4.0.0-beta.78)':
     dependencies:
-      '@distilled.cloud/core': 0.22.4(effect@4.0.0-beta.78)
+      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
+      effect: 4.0.0-beta.78
+
+  '@distilled.cloud/planetscale@0.24.9(effect@4.0.0-beta.78)':
+    dependencies:
+      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
       effect: 4.0.0-beta.78
 
   '@dotenvx/dotenvx@1.71.0':
@@ -5966,6 +5995,26 @@ snapshots:
   '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
     dependencies:
       '@noble/ciphers': 1.3.0
+
+  '@effect/platform-node-shared@4.0.0-beta.80(effect@4.0.0-beta.78)':
+    dependencies:
+      '@types/ws': 8.18.1
+      effect: 4.0.0-beta.78
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1)':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-beta.80(effect@4.0.0-beta.78)
+      effect: 4.0.0-beta.78
+      ioredis: 5.11.1
+      mime: 4.1.0
+      undici: 8.4.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@effect/vitest@4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))':
     dependencies:
@@ -6215,6 +6264,8 @@ snapshots:
   '@inquirer/type@4.0.7(@types/node@25.9.1)':
     optionalDependencies:
       '@types/node': 25.9.1
+
+  '@ioredis/commands@1.10.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -8070,20 +8121,20 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alchemy@2.0.0-beta.51(@types/node@25.9.1)(@types/react@19.2.16)(effect@4.0.0-beta.78)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260603.1)(ws@8.21.0):
+  alchemy@2.0.0-beta.55(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(@types/node@25.9.1)(@types/react@19.2.16)(effect@4.0.0-beta.78)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260603.1)(ws@8.21.0):
     dependencies:
-      '@alchemy.run/node-utils': 0.0.4
+      '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1063.0
       '@clack/prompts': 0.11.0
-      '@distilled.cloud/aws': 0.22.4(effect@4.0.0-beta.78)
-      '@distilled.cloud/axiom': 0.22.4(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare': 0.22.4(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare-rolldown-plugin': 0.10.2(rolldown@1.0.1)(workerd@1.20260603.1)
-      '@distilled.cloud/cloudflare-runtime': 0.10.2(@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78))(effect@4.0.0-beta.78)
-      '@distilled.cloud/cloudflare-vite-plugin': 0.10.2(@distilled.cloud/cloudflare-runtime@0.10.2(@distilled.cloud/cloudflare@0.22.4(effect@4.0.0-beta.78))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.22.4(effect@4.0.0-beta.78))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)
-      '@distilled.cloud/core': 0.22.4(effect@4.0.0-beta.78)
-      '@distilled.cloud/neon': 0.22.4(effect@4.0.0-beta.78)
-      '@distilled.cloud/planetscale': 0.22.4(effect@4.0.0-beta.78)
+      '@distilled.cloud/aws': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/axiom': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare-rolldown-plugin': 0.10.12(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)
+      '@distilled.cloud/cloudflare-runtime': 0.10.12(@distilled.cloud/cloudflare@0.23.1(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)
+      '@distilled.cloud/cloudflare-vite-plugin': 0.10.12(@distilled.cloud/cloudflare-runtime@0.10.12(@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78))(@distilled.cloud/cloudflare@0.24.9(effect@4.0.0-beta.78))(@effect/platform-node@4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1))(effect@4.0.0-beta.78)(rolldown@1.0.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(workerd@1.20260603.1)
+      '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/neon': 0.24.9(effect@4.0.0-beta.78)
+      '@distilled.cloud/planetscale': 0.24.9(effect@4.0.0-beta.78)
       '@effect/vitest': 4.0.0-beta.78(effect@4.0.0-beta.78)(vitest@4.1.8(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))
       '@libsql/client': 0.17.3
       '@octokit/rest': 22.0.1
@@ -8109,6 +8160,7 @@ snapshots:
       undici: 7.27.2
       yaml: 2.9.0
     optionalDependencies:
+      '@effect/platform-node': 4.0.0-beta.78(effect@4.0.0-beta.78)(ioredis@5.11.1)
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)
       ws: 8.21.0
     transitivePeerDependencies:
@@ -8240,8 +8292,6 @@ snapshots:
 
   capnweb@0.6.1: {}
 
-  capnweb@0.7.0: {}
-
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
@@ -8255,10 +8305,6 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
-
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
 
   chokidar@5.0.0:
     dependencies:
@@ -8294,6 +8340,8 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.1: {}
 
   code-block-writer@13.0.3: {}
 
@@ -8889,6 +8937,18 @@ snapshots:
       - utf-8-validate
 
   inline-style-parser@0.2.7: {}
+
+  ioredis@5.11.1:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ip-address@10.2.0: {}
 
@@ -9520,6 +9580,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@4.1.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
@@ -9675,10 +9737,6 @@ snapshots:
       stdin-discarder: 0.2.2
       string-width: 7.2.0
       strip-ansi: 7.2.0
-
-  os-paths@7.4.0:
-    optionalDependencies:
-      fsevents: 2.3.3
 
   outvariant@1.4.3: {}
 
@@ -10009,8 +10067,6 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
-  readdirp@4.1.2: {}
-
   readdirp@5.0.0: {}
 
   recast@0.23.11:
@@ -10020,6 +10076,12 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
 
   remark-breaks@4.0.0:
     dependencies:
@@ -10341,6 +10403,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standard-as-callback@2.1.0: {}
+
   statuses@2.0.2: {}
 
   std-env@4.1.0: {}
@@ -10490,6 +10554,8 @@ snapshots:
   undici@7.24.8: {}
 
   undici@7.27.2: {}
+
+  undici@8.4.1: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -10729,18 +10795,6 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
-
-  xdg-app-paths@8.3.0:
-    dependencies:
-      xdg-portable: 10.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  xdg-portable@10.6.0:
-    dependencies:
-      os-paths: 7.4.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   xml-name-validator@5.0.0: {}
 

--- a/apps/f311x/pnpm-workspace.yaml
+++ b/apps/f311x/pnpm-workspace.yaml
@@ -5,3 +5,14 @@ allowBuilds:
   msw: true
   sharp: true
   workerd: true
+
+# Pinned because pnpm's release-age supply-chain policy rejects packages
+# published <24h ago; these track alchemy 2.0.0-beta.54 (see plan.md).
+overrides:
+  '@distilled.cloud/aws': 0.24.8
+  '@distilled.cloud/axiom': 0.24.8
+  '@distilled.cloud/cloudflare': 0.24.8
+  '@distilled.cloud/core': 0.24.8
+  '@distilled.cloud/neon': 0.24.8
+  '@distilled.cloud/planetscale': 0.24.8
+  '@effect/platform-node-shared': 4.0.0-beta.78

--- a/docs/projects/f311x/2026-06-11-progress.md
+++ b/docs/projects/f311x/2026-06-11-progress.md
@@ -32,3 +32,66 @@ previews so this class of breakage is visible, then return to the model swap.
 
 - [plan.md](./plan.md)
 - [preview-deployments plan](../preview-deployments/plan.md)
+
+---
+
+# Session 2 — diagnosis and ingress fix
+
+## Session summary
+
+Diagnosed the production breakage. It is not runtime breakage in the Worker —
+**the app has no ingress**. f311x.com has never pointed at anything.
+
+## Symptom
+
+- `https://f311x.com` does not resolve (browser "site can't be reached").
+- DNS evidence: the f311x.com zone exists on Cloudflare (NS
+  `betty`/`darwin.ns.cloudflare.com` — the same assigned pair as
+  davidjfelix.com and djf.io, so same account), but the zone has **zero
+  address records**: A/AAAA/CNAME at the apex return NOERROR with an empty
+  answer, and `www` is NXDOMAIN.
+
+## Root cause
+
+- `alchemy.run.ts` never set the `domain` option on the `Cloudflare.Vite`
+  resource, so no custom domain was ever attached to the prod Worker
+  (`f311x-website-prod-ddptpca6nyzpodvc`, deployed 2026-06-06 and still
+  present in the account).
+- Unlike the wrangler apps (davidjfelix.com declares
+  `routes = [{ pattern = "davidjfelix.com", custom_domain = true }]`), f311x's
+  `wrangler.toml` is a stub and nothing else wires the domain. Repo history
+  confirms no domain config ever existed.
+- The deploy pipeline was honestly green: it verifies that the Worker uploads,
+  not that anything routes to it. This is the precise gap the
+  preview-deployments smoke test exists to close.
+
+## Work completed
+
+- `apps/f311x/alchemy.run.ts`: added
+  `domain: ['f311x.com', 'www.f311x.com']` — Alchemy attaches both as Workers
+  custom domains on deploy and Cloudflare materializes the DNS records
+  (verified against the `alchemy@2.0.0-beta.51` source: `WorkerProps.domain`,
+  reconciled via `PUT /accounts/:id/workers/domains` after script upload).
+- `.github/workflows/cd-deploy-f311x.yml`: added `workflow_dispatch` so prod
+  deploys can be re-run on demand (the 2026-06-06 note's open follow-up).
+- `plan.md`: recorded the diagnosis and the custom-domain token-scope caveat.
+
+## Decisions made
+
+- Bind both apex and `www`, matching davidjfelix.com's pattern.
+- Keep the workers.dev URL at Alchemy's default (enabled) as a fallback ingress
+  for debugging.
+
+## Next steps
+
+- Merge to main (or `workflow_dispatch` the CD job) to deploy the domain
+  binding, then verify `https://f311x.com` loads and the chat echo works.
+- If the deploy fails with a generic `10000 Authentication error`, the token is
+  missing a zone scope — see the plan's token-scopes section (issue filed for
+  David).
+
+## Blockers or open questions
+
+- The `F311X_CLOUDFLARE_API_TOKEN` scopes can't be inspected from this
+  environment; whether domain-attach needs **Zone · DNS · Edit** /
+  **Zone · Workers Routes · Edit** is unverified until the next deploy runs.

--- a/docs/projects/f311x/2026-06-11-progress.md
+++ b/docs/projects/f311x/2026-06-11-progress.md
@@ -35,63 +35,102 @@ previews so this class of breakage is visible, then return to the model swap.
 
 ---
 
-# Session 2 — diagnosis and ingress fix
+# Session 2 — diagnosis and fixes
 
 ## Session summary
 
-Diagnosed the production breakage. It is not runtime breakage in the Worker —
-**the app has no ingress**. f311x.com has never pointed at anything.
+Diagnosed the production breakage end to end. Three stacked failures, all
+invisible to the current checks:
 
-## Symptom
+1. **No ingress** — f311x.com has never pointed at anything.
+2. **Every deploy since 2026-06-08 has failed** — the alchemy CLI crashes at
+   startup, so the echo backend (#211) never shipped.
+3. **The artifact prod serves is a dev-mode build** — the page shell loads but
+   the app can never hydrate.
 
-- `https://f311x.com` does not resolve (browser "site can't be reached").
-- DNS evidence: the f311x.com zone exists on Cloudflare (NS
-  `betty`/`darwin.ns.cloudflare.com` — the same assigned pair as
-  davidjfelix.com and djf.io, so same account), but the zone has **zero
-  address records**: A/AAAA/CNAME at the apex return NOERROR with an empty
-  answer, and `www` is NXDOMAIN.
+All three are fixed on this branch; restoring prod needs one merge + deploy.
 
-## Root cause
+## Symptoms
 
-- `alchemy.run.ts` never set the `domain` option on the `Cloudflare.Vite`
-  resource, so no custom domain was ever attached to the prod Worker
-  (`f311x-website-prod-ddptpca6nyzpodvc`, deployed 2026-06-06 and still
-  present in the account).
-- Unlike the wrangler apps (davidjfelix.com declares
-  `routes = [{ pattern = "davidjfelix.com", custom_domain = true }]`), f311x's
-  `wrangler.toml` is a stub and nothing else wires the domain. Repo history
-  confirms no domain config ever existed.
-- The deploy pipeline was honestly green: it verifies that the Worker uploads,
-  not that anything routes to it. This is the precise gap the
-  preview-deployments smoke test exists to close.
+- `https://f311x.com` does not resolve. The zone exists on Cloudflare (NS
+  `betty`/`darwin.ns.cloudflare.com` — same assigned pair as davidjfelix.com
+  and djf.io, so same account) but has **zero address records**: apex
+  A/AAAA/CNAME return NOERROR with an empty answer; `www` is NXDOMAIN.
+- The Worker URL
+  (`https://f311x-website-prod-ddptpca6nyzpodvc.nullserve.workers.dev`,
+  recovered from the 2026-06-06 deploy logs) serves HTTP 200 HTML whose
+  client entry is `/@id/virtual:tanstack-start-dev-client-entry` — a Vite
+  **dev-server** virtual module that 404s in production. Real assets (the
+  hashed CSS) serve fine; the JS never loads, so the page is dead. The chat
+  endpoint 404s because the deployed build predates #211.
+- `CD Deploy f311x` run history: the *only* success ever is 2026-06-06 (run
+  attempt 21, after the Secrets Store token fix). Every run since —
+  #207 (2026-06-08), #208, #211, #206, and #214 (2026-06-11) — failed.
 
-## Work completed
+## Root causes
 
-- `apps/f311x/alchemy.run.ts`: added
-  `domain: ['f311x.com', 'www.f311x.com']` — Alchemy attaches both as Workers
-  custom domains on deploy and Cloudflare materializes the DNS records
-  (verified against the `alchemy@2.0.0-beta.51` source: `WorkerProps.domain`,
-  reconciled via `PUT /accounts/:id/workers/domains` after script upload).
+1. **Ingress**: `alchemy.run.ts` never set `domain` on the `Cloudflare.Vite`
+   resource, so no custom domain was attached and no DNS records were ever
+   created. Unlike the wrangler apps (davidjfelix.com declares
+   `custom_domain = true` routes), f311x's `wrangler.toml` is a stub. Repo
+   history confirms domain config never existed.
+2. **Deploy pipeline**: #207 (renovate) bumped alchemy 2.0.0-beta.45 → beta.51;
+   the CLI then died at startup with a `TypeError ... (reading 'encoding')` in
+   `effect@4.0.0-beta.78/dist/SchemaAST.js`. #208 (lockfile maintenance) then
+   pruned `@effect/platform-node` from the lockfile — it is an *optional peer*
+   of alchemy that nothing declared, but alchemy's `WorkerBridge.js` imports it
+   unconditionally — flipping the crash to
+   `ERR_MODULE_NOT_FOUND: @effect/platform-node` (reproduced locally).
+3. **Dev-mode artifact**: the 2026-06-06 deploy (alchemy beta.45 + floating
+   `@tanstack/react-start: latest`) uploaded an SSR bundle whose rendered HTML
+   references the dev client entry while client assets were built for
+   production. The current toolchain does not reproduce it.
+
+## Fixes (this branch)
+
+- `alchemy.run.ts`: `domain: ['f311x.com', 'www.f311x.com']` — Alchemy
+  attaches Workers custom domains on deploy; Cloudflare materializes DNS.
+- `package.json` / lockfile: alchemy → `2.0.0-beta.55` (current `next`);
+  added devDependency `@effect/platform-node@4.0.0-beta.78`, pinned to match
+  `effect` exactly so lockfile maintenance can't orphan it again and the
+  effect instance stays single (mixed effect versions are the prime suspect
+  for the SchemaAST TypeError).
 - `.github/workflows/cd-deploy-f311x.yml`: added `workflow_dispatch` so prod
   deploys can be re-run on demand (the 2026-06-06 note's open follow-up).
-- `plan.md`: recorded the diagnosis and the custom-domain token-scope caveat.
+
+## Verification (local, no deploy creds in this environment)
+
+- `pnpm exec alchemy deploy --stage prod --yes` now gets past module load and
+  schema construction and stops at the Cloudflare **authentication prompt** —
+  exactly where CI's env vars take over. Both historical crash points cleared.
+- `pnpm build` output has zero `virtual:tanstack-start-dev-client-entry`
+  references; `vite preview` (workerd) serves HTML with real hashed assets and
+  `POST /agents/chat-agent/default` streams the full AG-UI echo lifecycle.
+- `pnpm test` 15/15 green; `pnpm typecheck` green; lockfile diff scoped to
+  alchemy/platform-node and their transitive deps (no app dep bumps).
 
 ## Decisions made
 
 - Bind both apex and `www`, matching davidjfelix.com's pattern.
-- Keep the workers.dev URL at Alchemy's default (enabled) as a fallback ingress
-  for debugging.
+- Keep the workers.dev URL at Alchemy's default (enabled) as a fallback
+  ingress for debugging.
+- Pin `@effect/platform-node` exactly to effect's version rather than a range.
 
 ## Next steps
 
-- Merge to main (or `workflow_dispatch` the CD job) to deploy the domain
-  binding, then verify `https://f311x.com` loads and the chat echo works.
-- If the deploy fails with a generic `10000 Authentication error`, the token is
-  missing a zone scope — see the plan's token-scopes section (issue filed for
-  David).
+- Merge to main (or `workflow_dispatch` the CD job). The deploy rebuilds with
+  the repaired toolchain — replacing the dev-mode artifact — and attaches the
+  custom domains.
+- Verify `https://f311x.com` resolves, hydrates, and the chat echo streams;
+  also spot-check the workers.dev URL.
+- If the deploy fails with a generic `10000 Authentication error`, the token
+  is missing a zone scope — see the plan's token-scopes section (issue #220).
 
 ## Blockers or open questions
 
 - The `F311X_CLOUDFLARE_API_TOKEN` scopes can't be inspected from this
   environment; whether domain-attach needs **Zone · DNS · Edit** /
   **Zone · Workers Routes · Edit** is unverified until the next deploy runs.
+- Deploy failures were silent for three days — no notification gates them.
+  The preview-deployments project (post-deploy smoke test) closes this; until
+  then, the CD workflow's status is worth a glance after any f311x merge.

--- a/docs/projects/f311x/2026-06-11-progress.md
+++ b/docs/projects/f311x/2026-06-11-progress.md
@@ -90,11 +90,20 @@ All three are fixed on this branch; restoring prod needs one merge + deploy.
 
 - `alchemy.run.ts`: `domain: ['f311x.com', 'www.f311x.com']` — Alchemy
   attaches Workers custom domains on deploy; Cloudflare materializes DNS.
-- `package.json` / lockfile: alchemy → `2.0.0-beta.55` (current `next`);
-  added devDependency `@effect/platform-node@4.0.0-beta.78`, pinned to match
-  `effect` exactly so lockfile maintenance can't orphan it again and the
-  effect instance stays single (mixed effect versions are the prime suspect
-  for the SchemaAST TypeError).
+- `package.json` / lockfile: alchemy → `2.0.0-beta.54`; added devDependency
+  `@effect/platform-node@4.0.0-beta.78`, pinned to match `effect` exactly so
+  lockfile maintenance can't orphan it again and the effect instance stays
+  single (mixed effect versions are the prime suspect for the SchemaAST
+  TypeError). Dropped the vestigial direct `@distilled.cloud/cloudflare`
+  dependency (nothing imports it; alchemy brings its own).
+- **CI follow-up (same day)**: the first PR run failed in `pnpm install` —
+  pnpm 11's default supply-chain policy rejects lockfile entries published
+  <24h ago, and alchemy beta.55 + its `@distilled.cloud/*@0.24.9` transitives
+  + `@effect/platform-node-shared@4.0.0-beta.80` were all too fresh. Resolved
+  by stepping alchemy back to beta.54 (28h old, verified equivalent for our
+  use) and adding `pnpm.overrides` pinning `@distilled.cloud/*` → `0.24.8`
+  (released the same minute as beta.54) and `platform-node-shared` →
+  `4.0.0-beta.78`. All pins only get older, so this stays policy-clean.
 - `.github/workflows/cd-deploy-f311x.yml`: added `workflow_dispatch` so prod
   deploys can be re-run on demand (the 2026-06-06 note's open follow-up).
 

--- a/docs/projects/f311x/plan.md
+++ b/docs/projects/f311x/plan.md
@@ -5,17 +5,28 @@ A small chat app on Cloudflare — TanStack Start front end, deployed via Alchem
 
 ## Current state (2026-06-11)
 
-- **Diagnosed: the app has no ingress — f311x.com was never wired to the
-  Worker.** The prod Worker (`f311x-website-prod-…`) deployed fine on
-  2026-06-06, but `alchemy.run.ts` never set the `domain` option, so no custom
-  domain is attached, the f311x.com zone (on Cloudflare, same account) has zero
-  DNS records, and the site never resolves. Not a runtime crash — requests
-  never reach the Worker. "Green deploy, broken prod" because the pipeline
-  verifies upload, not reachability. Fix in flight: `domain: ['f311x.com',
-  'www.f311x.com']` on the `Cloudflare.Vite` resource; Cloudflare materializes
-  the DNS records when the custom domains attach on the next prod deploy. One
-  open risk: the deploy token may need a zone scope to attach domains — see the
-  token-scopes section. Details in the 2026-06-11 progress note.
+- **Diagnosed — three stacked failures, fixes in flight on `claude/relaxed-tesla-4bwmbj`:**
+  1. **No ingress**: `alchemy.run.ts` never set `domain`, so f311x.com has zero
+     DNS records and no custom domain is attached to the Worker. Fixed by
+     binding `f311x.com` / `www.f311x.com`.
+  2. **Every deploy since 2026-06-08 has failed.** #207 bumped alchemy
+     beta.45→51, which crashed the CLI at startup (effect `SchemaAST`
+     TypeError); #208's lockfile maintenance then removed
+     `@effect/platform-node` (an optional peer alchemy's `WorkerBridge.js`
+     imports unconditionally), changing the crash to `ERR_MODULE_NOT_FOUND`.
+     The echo backend (#211) never reached prod. Fixed: alchemy → beta.55 plus
+     an explicit `@effect/platform-node` devDependency pinned to effect's
+     version; the CLI now reaches Cloudflare auth cleanly.
+  3. **The artifact prod is serving is a dev-mode build** (the only successful
+     deploy, 2026-06-06, alchemy beta.45 + floating `@tanstack/react-start`).
+     Its SSR HTML references `/@id/virtual:tanstack-start-dev-client-entry`,
+     which 404s — page shell loads, app never hydrates. Verified the current
+     toolchain builds a correct production bundle (real hashed assets, echo
+     SSE works under workerd via `vite preview`). A fresh deploy replaces the
+     artifact.
+- One open risk: the deploy token may need a zone scope to attach the custom
+  domains — see the token-scopes section. Full details in the 2026-06-11
+  progress note.
 
 ## Earlier state (2026-06-08)
 
@@ -46,9 +57,11 @@ Stabilize before building (reprioritized 2026-06-11).
 - [x] Diagnose why prod is broken; capture the symptom and root cause in a
       progress note. (2026-06-11: no ingress — no custom domain on the Worker,
       no DNS records in the zone. See the progress note.)
-- [ ] Restore ingress: deploy the `domain` binding (merge to main triggers CD,
-      or `workflow_dispatch` re-runs it) and verify https://f311x.com loads.
-      May require granting the deploy token a zone scope first.
+- [ ] Restore prod: merge the fix branch (CD deploys on merge, or
+      `workflow_dispatch` re-runs it). The deploy rebuilds with the repaired
+      toolchain (replacing the dev-mode artifact) and attaches the custom
+      domains. Verify https://f311x.com loads, hydrates, and the chat echo
+      streams. May require granting the deploy token a zone scope first.
 - [ ] Make breakage readable: error visibility for the Worker (Cloudflare
       logs/tail and/or the f311x slice of
       [Sentry Integration](../sentry-integration/plan.md) pulled forward) so

--- a/docs/projects/f311x/plan.md
+++ b/docs/projects/f311x/plan.md
@@ -14,9 +14,11 @@ A small chat app on Cloudflare — TanStack Start front end, deployed via Alchem
      TypeError); #208's lockfile maintenance then removed
      `@effect/platform-node` (an optional peer alchemy's `WorkerBridge.js`
      imports unconditionally), changing the crash to `ERR_MODULE_NOT_FOUND`.
-     The echo backend (#211) never reached prod. Fixed: alchemy → beta.55 plus
+     The echo backend (#211) never reached prod. Fixed: alchemy → beta.54 plus
      an explicit `@effect/platform-node` devDependency pinned to effect's
-     version; the CLI now reaches Cloudflare auth cleanly.
+     version; the CLI now reaches Cloudflare auth cleanly. (beta.55 worked too
+     but is <24h old and pnpm's release-age policy rejects it in CI; pnpm
+     overrides pin the too-fresh transitives to ≥24h-old releases.)
   3. **The artifact prod is serving is a dev-mode build** (the only successful
      deploy, 2026-06-06, alchemy beta.45 + floating `@tanstack/react-start`).
      Its SSR HTML references `/@id/virtual:tanstack-start-dev-client-entry`,

--- a/docs/projects/f311x/plan.md
+++ b/docs/projects/f311x/plan.md
@@ -5,12 +5,17 @@ A small chat app on Cloudflare — TanStack Start front end, deployed via Alchem
 
 ## Current state (2026-06-11)
 
-- **Broken in production.** Reported by David 2026-06-11; cause not yet
-  diagnosed, symptom not yet captured. CI was green and the deploy pipeline
-  succeeded, so this is runtime breakage the current checks cannot see — which
-  is exactly the gap the new
-  [preview-deployments](../preview-deployments/plan.md) project exists to
-  close. Diagnosis comes before any new feature work.
+- **Diagnosed: the app has no ingress — f311x.com was never wired to the
+  Worker.** The prod Worker (`f311x-website-prod-…`) deployed fine on
+  2026-06-06, but `alchemy.run.ts` never set the `domain` option, so no custom
+  domain is attached, the f311x.com zone (on Cloudflare, same account) has zero
+  DNS records, and the site never resolves. Not a runtime crash — requests
+  never reach the Worker. "Green deploy, broken prod" because the pipeline
+  verifies upload, not reachability. Fix in flight: `domain: ['f311x.com',
+  'www.f311x.com']` on the `Cloudflare.Vite` resource; Cloudflare materializes
+  the DNS records when the custom domains attach on the next prod deploy. One
+  open risk: the deploy token may need a zone scope to attach domains — see the
+  token-scopes section. Details in the 2026-06-11 progress note.
 
 ## Earlier state (2026-06-08)
 
@@ -38,8 +43,12 @@ A small chat app on Cloudflare — TanStack Start front end, deployed via Alchem
 
 Stabilize before building (reprioritized 2026-06-11).
 
-- [ ] Diagnose why prod is broken; capture the symptom and root cause in a
-      progress note.
+- [x] Diagnose why prod is broken; capture the symptom and root cause in a
+      progress note. (2026-06-11: no ingress — no custom domain on the Worker,
+      no DNS records in the zone. See the progress note.)
+- [ ] Restore ingress: deploy the `domain` binding (merge to main triggers CD,
+      or `workflow_dispatch` re-runs it) and verify https://f311x.com loads.
+      May require granting the deploy token a zone scope first.
 - [ ] Make breakage readable: error visibility for the Worker (Cloudflare
       logs/tail and/or the f311x slice of
       [Sentry Integration](../sentry-integration/plan.md) pulled forward) so
@@ -83,6 +92,14 @@ Stabilize before building (reprioritized 2026-06-11).
 
 Only **Secrets Store: Edit** was missing on the first run; the resource scopes were
 already granted. See the Alchemy CI/CD guide and the 2026-06-06 progress note.
+
+**Custom domains (unverified scope)**: attaching `f311x.com` / `www.f311x.com`
+to the Worker creates DNS records in the zone. Cloudflare doesn't document the
+exact token permission for `PUT /accounts/:id/workers/domains`; if the deploy
+fails with another generic `10000 "Authentication error"`, grant the token
+**Zone · Workers Routes · Edit** and/or **Zone · DNS · Edit** scoped to
+f311x.com. Note the f311x workflow uses its own `F311X_CLOUDFLARE_API_TOKEN`
+secret, not the shared `CLOUDFLARE_API_TOKEN` the wrangler apps use.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

Diagnosed and fixed three stacked production failures in f311x that were invisible to current checks: missing ingress (no custom domain), broken deploy pipeline (alchemy CLI crashes), and a dev-mode artifact being served. All fixes are in this branch; restoring prod requires one merge + deploy.

## Changes

- **alchemy.run.ts**: Added `domain: ['f311x.com', 'www.f311x.com']` to the `Cloudflare.Vite` resource so Alchemy attaches custom domains on deploy and Cloudflare materializes DNS records.
- **package.json**: Bumped `alchemy` from `2.0.0-beta.51` to `2.0.0-beta.55` (current `next` branch) to fix the CLI startup crash in the effect `SchemaAST` module.
- **package.json devDependencies**: Added `@effect/platform-node@4.0.0-beta.78` pinned exactly to match `effect`'s version. This is an optional peer of alchemy that was being orphaned by lockfile maintenance, causing `ERR_MODULE_NOT_FOUND` on every deploy since 2026-06-08.
- **.github/workflows/cd-deploy-f311x.yml**: Added `workflow_dispatch` trigger so prod deploys can be re-run on demand without waiting for a commit.

## Changelog entry

```markdown
### fix(f311x): restore production — ingress, deploy pipeline, artifact

Diagnosed three stacked failures invisible to current checks:

1. **No ingress**: `alchemy.run.ts` never set `domain`, so f311x.com had zero DNS records and no custom domain attached to the Worker. Fixed by binding `f311x.com` and `www.f311x.com`.

2. **Every deploy since 2026-06-08 failed**: alchemy beta.51 crashed the CLI at startup (effect `SchemaAST` TypeError); lockfile maintenance then removed `@effect/platform-node` (an optional peer alchemy imports unconditionally), changing the crash to `ERR_MODULE_NOT_FOUND`. Fixed: alchemy → beta.55 plus explicit `@effect/platform-node` devDependency pinned to effect's version.

3. **Dev-mode artifact in production**: the only successful deploy (2026-06-06) served SSR HTML referencing `/@id/virtual:tanstack-start-dev-client-entry`, which 404s in production. A fresh deploy replaces it with a correct production bundle.

Also added `workflow_dispatch` to the CD workflow for manual re-runs.
```

## Testing

- [x] `pnpm build` produces zero `virtual:tanstack-start-dev-client-entry` references; `vite preview` serves real hashed assets and the chat echo streams correctly.
- [x] `pnpm exec alchemy deploy --stage prod --yes` now passes module load and schema construction, stopping only at the Cloudflare authentication prompt (where CI env vars take over). Both historical crash points cleared.
- [x] `pnpm test` 15/15 green; `pnpm typecheck` green.
- [x] Lockfile diff scoped to alchemy/platform-node and transitive deps only (no app dependency bumps).

**Next step (requires deploy credentials)**: Merge to main or `workflow_dispatch` the CD job. The deploy rebuilds with the repaired toolchain and attaches the custom domains. Verify `https://f311x.com` resolves, hydrates, and the chat echo streams. If the deploy fails with `10000 Authentication error`, the token may need **Zone · Workers Routes · Edit** and/or **Zone · DNS · Edit** scopes — see the plan's token-scopes section.

https://claude.ai/code/session_017S5jRTLaWninjiWBqgqnT2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production DNS/Worker routing and deploy dependencies; success depends on Cloudflare token scopes for custom domains, but app runtime code is largely unchanged.
> 
> **Overview**
> Restores **f311x** production by fixing ingress, the Alchemy deploy toolchain, and what gets shipped on the next deploy.
> 
> **Ingress:** `Cloudflare.Vite` in `alchemy.run.ts` now sets `domain: ['f311x.com', 'www.f311x.com']` so deploy attaches Workers custom domains and Cloudflare can create DNS for the zone.
> 
> **Deploy pipeline:** Bumps **alchemy** to `2.0.0-beta.54`, adds **`@effect/platform-node@4.0.0-beta.78`** as a devDependency (pinned to `effect`) so the CLI no longer crashes on startup or on missing `WorkerBridge` imports. Removes the unused direct **`@distilled.cloud/cloudflare`** dependency. **`pnpm-workspace.yaml`** (and lockfile) add **overrides** for `@distilled.cloud/*` and `@effect/platform-node-shared` so CI’s release-age policy accepts installs.
> 
> **Ops:** **`cd-deploy-f311x.yml`** gains **`workflow_dispatch`** for on-demand prod deploys.
> 
> **Docs:** `plan.md` and the 2026-06-11 progress note document the three stacked prod failures and these fixes; token scope for domain attach remains an open deploy-time risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23efbb3fb0f9541b246c0f76f0bdf8c48269054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->