### PR TITLE
fix(f311x): bootstrap the alchemy state store before deploying in CI

### DIFF
--- a/.github/workflows/cd-deploy-f311x.yml
+++ b/.github/workflows/cd-deploy-f311x.yml
@@ -34,6 +34,20 @@ jobs:
       - name: pnpm install
         run: pnpm install --frozen-lockfile
 
+      # Alchemy's state lives in a state-store Worker on the account. The CLI
+      # refuses to create or upgrade it implicitly in CI (it dies with
+      # "Cloudflare State store not found"), so bootstrap explicitly first.
+      # With an up-to-date store this adopts it and only refreshes
+      # credentials, so it is cheap and idempotent; on Alchemy version bumps
+      # it upgrades the store instead of failing the deploy.
+      - name: alchemy bootstrap state store
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.F311X_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.F311X_CLOUDFLARE_ACCOUNT_ID }}
+          ALCHEMY_NO_TUI: '1'
+          ALCHEMY_TELEMETRY_DISABLED: '1'
+        run: pnpm exec alchemy cloudflare bootstrap
+
       # Alchemy's Cloudflare.Vite resource builds the client + server bundle
       # itself during deploy, so there is no separate build step. The stage is
       # pinned because `alchemy deploy` otherwise defaults to `dev_${USER}`,

--- a/docs/projects/f311x/2026-06-11-progress.md
+++ b/docs/projects/f311x/2026-06-11-progress.md
@@ -135,6 +135,25 @@ All three are fixed on this branch; restoring prod needs one merge + deploy.
 - If the deploy fails with a generic `10000 Authentication error`, the token
   is missing a zone scope — see the plan's token-scopes section (issue #220).
 
+## Post-merge deploy failure 1 — state store version gate
+
+The first post-merge deploy (#221, run 2) failed in seconds with
+`AuthError: Cloudflare State store not found. Run 'alchemy bootstrap
+cloudflare' ...`. The `alchemy-state-store` Worker on the account was
+deployed by the beta.45 CLI; beta.54's state layer version-checks the store
+and, **in CI, refuses to create or upgrade it implicitly** (the source
+literally says "for now - just die"). Locally it would have prompted to
+upgrade. The CLI's suggested command is also stale — in beta.54 it is
+`alchemy cloudflare bootstrap`, not `alchemy bootstrap cloudflare`.
+
+Fix: added an explicit `alchemy cloudflare bootstrap` step to
+`cd-deploy-f311x.yml` before the deploy. Verified from the beta.54 source
+that the bootstrap path is fully headless under CI: API-token env
+credentials, Secrets Store lookup, an edge-preview worker to read the
+auth token, no prompts; when the store exists and is current it only
+refreshes credentials, and when it is outdated it upgrades it — so the
+step is idempotent and self-heals future alchemy version bumps.
+
 ## Blockers or open questions
 
 - The `F311X_CLOUDFLARE_API_TOKEN` scopes can't be inspected from this


### PR DESCRIPTION
## Summary

The post-merge deploy from #221 failed in seconds with:

```
AuthError: Cloudflare State store not found. Run 'alchemy bootstrap cloudflare --profile <your-ci-profile>' to deploy it first.
```

The account's `alchemy-state-store` Worker was deployed by the beta.45 CLI. alchemy beta.54 version-checks the store at startup and, **in CI specifically, refuses to create or upgrade it implicitly** — the implicit path is interactive-only (locally it prompts to upgrade). The error's suggested command is also stale: in beta.54 the subcommand is `alchemy cloudflare bootstrap`, not `alchemy bootstrap cloudflare`.

## Changes

- **`.github/workflows/cd-deploy-f311x.yml`**: add an `alchemy cloudflare bootstrap` step before `alchemy deploy`, using the same `CLOUDFLARE_*` env.
- **docs**: record the failure and fix in the 2026-06-11 progress note.

## Why this is safe to run on every deploy

Verified against the `alchemy@2.0.0-beta.54` source (`src/Cloudflare/StateStore/State.ts`):

- The bootstrap path is fully headless under `CI=true`: API-token env credentials, Secrets Store lookup, an edge-preview worker to read the auth token — no prompts, no profile files.
- When the store exists and is current, it adopts it and only refreshes credentials (cheap, idempotent).
- When the store is outdated (this case), it upgrades it in place — so future alchemy version bumps self-heal instead of failing the deploy.

## Testing

- [x] `pnpm exec alchemy cloudflare bootstrap --help` confirms the subcommand and flags (no required flags).
- [x] Bootstrap behavior in CI verified by source inspection (no Cloudflare credentials available in this environment to run it end to end).
- [ ] Post-merge: CD runs bootstrap → deploy; verify https://f311x.com resolves, hydrates, and the chat echo streams. Remaining known risk: the domain-attach may need a zone scope on the token (issue #220).

Related: #220, #221

https://claude.ai/code/session_017S5jRTLaWninjiWBqgqnT2

---
_Generated by [Claude Code](https://claude.ai/code/session_017S5jRTLaWninjiWBqgqnT2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow ordering change with idempotent bootstrap; no app runtime or auth logic changes.
> 
> **Overview**
> Fixes post-merge CD failures where **alchemy beta.54** aborts in CI with *Cloudflare State store not found* because the CLI will not create or upgrade the account’s `alchemy-state-store` Worker implicitly in CI (only interactively locally).
> 
> **`cd-deploy-f311x.yml`** now runs **`pnpm exec alchemy cloudflare bootstrap`** immediately before **`alchemy deploy`**, reusing the same `CLOUDFLARE_*` and Alchemy headless env. Comments note the step is **idempotent**: adopt/refresh credentials when the store is current, upgrade when outdated.
> 
> **`docs/projects/f311x/2026-06-11-progress.md`** records this as “Post-merge deploy failure 1” and the bootstrap fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1259e5cd5f8c032f868041fb20ce2803b28453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->