### PR TITLE
fix(forzamonica.com): deploy with shared Cloudflare credentials to workers.dev

### DIFF
--- a/.github/workflows/cd-deploy-forzamonica-com.yml
+++ b/.github/workflows/cd-deploy-forzamonica-com.yml
@@ -48,7 +48,7 @@ jobs:
       - name: wrangler deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
-          apiToken: ${{ secrets.FORZAMONICA_CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.FORZAMONICA_CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy
           workingDirectory: apps/forzamonica.com

--- a/apps/forzamonica.com/wrangler.toml
+++ b/apps/forzamonica.com/wrangler.toml
@@ -4,10 +4,13 @@ main = "@tanstack/react-start/server-entry"
 compatibility_date = "2026-06-01"
 compatibility_flags = ["nodejs_compat"]
 
-routes = [
-  { pattern = "forzamonica.com", custom_domain = true },
-  { pattern = "www.forzamonica.com", custom_domain = true },
-]
+# forzamonica.com is not registered yet, so the worker serves from its
+# workers.dev URL. Once the domain is owned and its zone is in the account
+# (see GitHub issue #223), add:
+# routes = [
+#   { pattern = "forzamonica.com", custom_domain = true },
+#   { pattern = "www.forzamonica.com", custom_domain = true },
+# ]
 
 [observability]
 enabled = true

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -1,5 +1,15 @@
 # 2026-06
 
+## 2026-06-12
+
+### fix(forzamonica.com): deploy with shared Cloudflare credentials, workers.dev for now
+
+The CD workflow now uses the shared `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`
+secrets like every other app instead of unprovisioned per-app `FORZAMONICA_*` secrets.
+forzamonica.com is not registered yet, so the custom-domain `routes` were removed from
+`wrangler.toml` (left as a comment to restore) and the worker serves from its
+workers.dev URL until the domain exists.
+
 ## 2026-06-11
 
 ### feat(forzamonica.com): scaffold headless Shopify storefront

--- a/docs/projects/forzamonica-shop/plan.md
+++ b/docs/projects/forzamonica-shop/plan.md
@@ -35,9 +35,12 @@ Shopify-hosted checkout. This replaces the "placeholder for now" line item in
 
 ### Phase 2 — Accounts & plumbing (human)
 
+- [x] Cloudflare deploys use the shared `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`
+      secrets like the other apps (decided 2026-06-12); no per-app secrets
 - [ ] Shopify store + Headless channel + Storefront API token (GitHub issue)
-- [ ] Cloudflare secrets in GitHub + forzamonica.com zone/account confirmation (GitHub
-      issue)
+- [ ] Register forzamonica.com and add the zone to the account, then restore the
+      `routes` block in `wrangler.toml` (GitHub issue; worker serves from workers.dev
+      until then)
 - [ ] First production deploy on merge to main
 
 ### Phase 3 — Real store cutover


### PR DESCRIPTION
Deploy forzamonica.com with the shared Cloudflare credentials, per David.

- CD workflow now uses the shared `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets like every other app — the per-app `FORZAMONICA_*` secrets were never provisioned and the worker lives in the same account.
- forzamonica.com is **not registered yet**, so the custom-domain `routes` are removed from `wrangler.toml` (kept as a comment to restore) and the worker serves from its workers.dev URL. Issue #223 tracks registering the domain and restoring the routes.
- Plan + changelog updated to match.

Merging this triggers `cd-deploy-forzamonica-com.yml` (the workflow file is in its own path filter), which should produce the first successful deploy.

https://claude.ai/code/session_01HaAGCWX6qL7fJfktn6xcqg

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaAGCWX6qL7fJfktn6xcqg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/CD and wrangler config only; no app runtime or auth logic changes, and shared secrets are already used by other deploy workflows.
> 
> **Overview**
> Unblocks **forzamonica.com** CD by aligning with how other Workers apps deploy: the workflow now uses the shared `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets instead of unprovisioned `FORZAMONICA_*` credentials.
> 
> Because **forzamonica.com** is not registered yet, active custom-domain `routes` are removed from `wrangler.toml` (left commented for issue #223) so deploys target the worker’s **workers.dev** URL until the zone exists. Changelog and the forzamonica-shop plan reflect the credential decision and the domain follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f2d7750609597c19a4cb2d0cc7a805d42386e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->