### PR TITLE
fix(f311x): client-before-ssr build order (the real fix), CD hardening

### DIFF
--- a/.github/workflows/cd-deploy-f311x.yml
+++ b/.github/workflows/cd-deploy-f311x.yml
@@ -63,11 +63,51 @@ jobs:
       # Alchemy's Cloudflare.Vite resource builds the client + server bundle
       # itself during deploy, so there is no separate build step. The stage is
       # pinned because `alchemy deploy` otherwise defaults to `dev_${USER}`,
-      # which would be `dev_runner` in CI.
+      # which would be `dev_runner` in CI. Capped because the beta.54 CLI can
+      # finish the deploy and then never exit (observed on bootstrap in run
+      # 27387217212 and on a local deploy on 2026-06-12); only the timeout
+      # exit code is tolerated — real failures still fail here — and the
+      # smoke test below is the proof the deploy actually shipped.
       - name: alchemy deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.F311X_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.F311X_CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_NO_TUI: '1'
           ALCHEMY_TELEMETRY_DISABLED: '1'
-        run: pnpm exec alchemy deploy --stage prod --yes
+        run: |
+          set +e
+          timeout -k 15s 600s pnpm exec alchemy deploy --stage prod --yes
+          code=$?
+          set -e
+          if [ "$code" -eq 124 ]; then
+            echo "::warning::alchemy deploy hit the 10-minute cap (known beta.54 hang-after-success); the smoke test is the real gate"
+          elif [ "$code" -ne 0 ]; then
+            exit "$code"
+          fi
+
+      # The deploy's exit code can lie (hang-after-success, see above), so
+      # verify what production actually serves: HTML must reference hashed
+      # client assets and must NOT reference the Vite dev virtual entry that
+      # the dev-mode artifact shipped (the 2026-06-11/12 incident).
+      - name: smoke test
+        run: |
+          for url in \
+            'https://f311x-website-prod-ddptpca6nyzpodvc.nullserve.workers.dev/' \
+            'https://f311x.com/'; do
+            ok=''
+            for attempt in 1 2 3 4 5 6; do
+              curl -fsS --max-time 15 "$url" -o /tmp/smoke.html || true
+              if [ -s /tmp/smoke.html ] \
+                && ! grep -q 'virtual:tanstack-start-dev-client-entry' /tmp/smoke.html \
+                && grep -q 'src="/assets/' /tmp/smoke.html; then
+                echo "OK: $url serves a production bundle"
+                ok=1
+                break
+              fi
+              sleep 10
+            done
+            if [ -z "$ok" ]; then
+              echo "::error::$url is not serving a production bundle"
+              exit 1
+            fi
+          done

--- a/.github/workflows/cd-deploy-f311x.yml
+++ b/.github/workflows/cd-deploy-f311x.yml
@@ -7,6 +7,14 @@ on:
       - 'apps/f311x/**'
       - '.github/workflows/cd-deploy-f311x.yml'
   workflow_dispatch:
+    inputs:
+      bootstrap:
+        description: >-
+          Run `alchemy cloudflare bootstrap` before deploying. Only needed
+          when an alchemy version bump changes the state-store version and
+          the deploy fails with "Cloudflare State store not found".
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -34,19 +42,23 @@ jobs:
       - name: pnpm install
         run: pnpm install --frozen-lockfile
 
-      # Alchemy's state lives in a state-store Worker on the account. The CLI
-      # refuses to create or upgrade it implicitly in CI (it dies with
-      # "Cloudflare State store not found"), so bootstrap explicitly first.
-      # With an up-to-date store this adopts it and only refreshes
-      # credentials, so it is cheap and idempotent; on Alchemy version bumps
-      # it upgrades the store instead of failing the deploy.
+      # Alchemy's state lives in a versioned state-store Worker on the
+      # account. The CLI refuses to create or upgrade it implicitly in CI, so
+      # when an alchemy bump changes the store version the deploy fails with
+      # a misleading "Cloudflare State store not found" — re-run this
+      # workflow from the Actions tab with `bootstrap: true` to upgrade it.
+      # Manual-only because the store changes rarely and the beta.54 CLI
+      # never exits after a successful bootstrap (hence the timeout cap and
+      # tolerated exit code; the deploy step below is the real gate — it
+      # fails loudly if the store is absent or outdated).
       - name: alchemy bootstrap state store
+        if: github.event_name == 'workflow_dispatch' && inputs.bootstrap
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.F311X_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.F311X_CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_NO_TUI: '1'
           ALCHEMY_TELEMETRY_DISABLED: '1'
-        run: pnpm exec alchemy cloudflare bootstrap
+        run: timeout -k 10s 180s pnpm exec alchemy cloudflare bootstrap || true
 
       # Alchemy's Cloudflare.Vite resource builds the client + server bundle
       # itself during deploy, so there is no separate build step. The stage is

--- a/.github/workflows/cd-deploy-f311x.yml
+++ b/.github/workflows/cd-deploy-f311x.yml
@@ -24,7 +24,9 @@ jobs:
   deploy:
     name: alchemy deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Worst case: install (~1m) + manual bootstrap cap (3m) + deploy cap
+    # (10m) + smoke retries (~5m), with headroom.
+    timeout-minutes: 25
     permissions:
       contents: read
     steps:
@@ -47,12 +49,12 @@ jobs:
       # when an alchemy bump changes the store version the deploy fails with
       # a misleading "Cloudflare State store not found" — re-run this
       # workflow from the Actions tab with `bootstrap: true` to upgrade it.
-      # Manual-only because the store changes rarely and the beta.54 CLI
-      # never exits after a successful bootstrap (hence the timeout cap and
-      # tolerated exit code; the deploy step below is the real gate — it
-      # fails loudly if the store is absent or outdated).
+      # Manual-only because the store changes rarely; capped with a tolerated
+      # exit code because the beta.54 CLI never exits after a successful
+      # bootstrap (run 27387217212) — the deploy step fails loudly on its own
+      # if the store is actually absent or outdated.
       - name: alchemy bootstrap state store
-        if: github.event_name == 'workflow_dispatch' && inputs.bootstrap
+        if: github.event_name == 'workflow_dispatch' && inputs.bootstrap == true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.F311X_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.F311X_CLOUDFLARE_ACCOUNT_ID }}
@@ -60,54 +62,17 @@ jobs:
           ALCHEMY_TELEMETRY_DISABLED: '1'
         run: timeout -k 10s 180s pnpm exec alchemy cloudflare bootstrap || true
 
-      # Alchemy's Cloudflare.Vite resource builds the client + server bundle
-      # itself during deploy, so there is no separate build step. The stage is
-      # pinned because `alchemy deploy` otherwise defaults to `dev_${USER}`,
-      # which would be `dev_runner` in CI. Capped because the beta.54 CLI can
-      # finish the deploy and then never exit (observed on bootstrap in run
-      # 27387217212 and on a local deploy on 2026-06-12); only the timeout
-      # exit code is tolerated — real failures still fail here — and the
-      # smoke test below is the proof the deploy actually shipped.
+      # Builds happen inside `alchemy deploy` (Cloudflare.Vite resource), so
+      # there is no separate build step. The wrapper script documents and
+      # contains the one tolerated failure mode (CLI hang-after-success).
       - name: alchemy deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.F311X_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.F311X_CLOUDFLARE_ACCOUNT_ID }}
           ALCHEMY_NO_TUI: '1'
           ALCHEMY_TELEMETRY_DISABLED: '1'
-        run: |
-          set +e
-          timeout -k 15s 600s pnpm exec alchemy deploy --stage prod --yes
-          code=$?
-          set -e
-          if [ "$code" -eq 124 ]; then
-            echo "::warning::alchemy deploy hit the 10-minute cap (known beta.54 hang-after-success); the smoke test is the real gate"
-          elif [ "$code" -ne 0 ]; then
-            exit "$code"
-          fi
+        run: bun bin/deploy-prod.ts
 
-      # The deploy's exit code can lie (hang-after-success, see above), so
-      # verify what production actually serves: HTML must reference hashed
-      # client assets and must NOT reference the Vite dev virtual entry that
-      # the dev-mode artifact shipped (the 2026-06-11/12 incident).
+      # The real gate: fails unless prod serves a working production bundle.
       - name: smoke test
-        run: |
-          for url in \
-            'https://f311x-website-prod-ddptpca6nyzpodvc.nullserve.workers.dev/' \
-            'https://f311x.com/'; do
-            ok=''
-            for attempt in 1 2 3 4 5 6; do
-              curl -fsS --max-time 15 "$url" -o /tmp/smoke.html || true
-              if [ -s /tmp/smoke.html ] \
-                && ! grep -q 'virtual:tanstack-start-dev-client-entry' /tmp/smoke.html \
-                && grep -q 'src="/assets/' /tmp/smoke.html; then
-                echo "OK: $url serves a production bundle"
-                ok=1
-                break
-              fi
-              sleep 10
-            done
-            if [ -z "$ok" ]; then
-              echo "::error::$url is not serving a production bundle"
-              exit 1
-            fi
-          done
+        run: bun bin/smoke-test.ts

--- a/apps/f311x/alchemy.run.ts
+++ b/apps/f311x/alchemy.run.ts
@@ -31,9 +31,7 @@ export const Website = Cloudflare.Vite(
       // zone must already exist in this account. Prod-only: binding them
       // unconditionally let a local `alchemy deploy` (stage dev_${USER})
       // steal the public domains onto the dev worker (2026-06-12).
-      ...(stage === 'prod'
-        ? {domain: ['f311x.com', 'www.f311x.com']}
-        : {}),
+      ...(stage === 'prod' ? {domain: ['f311x.com', 'www.f311x.com']} : {}),
     }
   }),
 )

--- a/apps/f311x/alchemy.run.ts
+++ b/apps/f311x/alchemy.run.ts
@@ -17,16 +17,26 @@ import * as Effect from 'effect/Effect'
 // const WorkspaceBucket = Cloudflare.R2Bucket('AgentWorkspace')
 // const Gateway = Cloudflare.AiGateway('Gateway')
 
-export const Website = Cloudflare.Vite('Website', {
-  compatibility: {
-    date: '2026-05-01',
-    flags: ['nodejs_compat'],
-  },
-  // Custom domains are the Worker's only ingress: Alchemy attaches them on
-  // deploy and Cloudflare materializes the DNS records. The f311x.com zone
-  // must already exist in this account.
-  domain: ['f311x.com', 'www.f311x.com'],
-})
+export const Website = Cloudflare.Vite(
+  'Website',
+  Effect.gen(function* () {
+    const stage = yield* Alchemy.Stage
+    return {
+      compatibility: {
+        date: '2026-05-01',
+        flags: ['nodejs_compat'],
+      },
+      // Custom domains are the Worker's only ingress: Alchemy attaches them
+      // on deploy and Cloudflare materializes the DNS records. The f311x.com
+      // zone must already exist in this account. Prod-only: binding them
+      // unconditionally let a local `alchemy deploy` (stage dev_${USER})
+      // steal the public domains onto the dev worker (2026-06-12).
+      ...(stage === 'prod'
+        ? {domain: ['f311x.com', 'www.f311x.com']}
+        : {}),
+    }
+  }),
+)
 
 export default Alchemy.Stack(
   'f311x',

--- a/apps/f311x/bin/deploy-prod.ts
+++ b/apps/f311x/bin/deploy-prod.ts
@@ -1,0 +1,53 @@
+// Runs the prod deploy, tolerating exactly one failure mode: the alchemy
+// beta.54 CLI completes its work and then never exits. Observed twice on
+// 2026-06-11/12 — CI run 27387217212 printed "Done: 2 succeeded" then idled
+// 14.5 minutes until the job timeout, and a local `alchemy deploy` did the
+// same after uploading. No upstream issue exists yet (searched
+// alchemy-run/alchemy 2026-06-12; closest lineage is PRs #770/#840 about
+// dangling processes), so the evidence lives in those run logs.
+//
+// Policy: if alchemy exits nonzero on its own, that is a real failure and
+// this script propagates it. If alchemy is still running at the deadline,
+// we kill it and exit 0 with a warning — deliberately NOT trusting that
+// silence means success. The smoke test (bin/smoke-test.ts) is the gate
+// that decides whether the deploy actually shipped.
+
+const DEADLINE_MS = 10 * 60 * 1000
+
+// Test seam: lets the timeout/failure/success paths be exercised without
+// credentials (e.g. DEPLOY_PROD_TEST_CMD='sleep 999').
+const cmd = process.env.DEPLOY_PROD_TEST_CMD?.split(' ') ?? [
+  'pnpm',
+  'exec',
+  'alchemy',
+  'deploy',
+  '--stage',
+  'prod',
+  '--yes',
+]
+
+const proc = Bun.spawn({cmd, stdout: 'inherit', stderr: 'inherit'})
+
+// Bun's Subprocess.killed is true for any exited process, so track the
+// deadline path explicitly.
+let timedOut = false
+const timer = setTimeout(() => {
+  timedOut = true
+  console.warn(
+    `::warning::alchemy deploy still running after ${DEADLINE_MS / 60000} minutes — ` +
+      'presumed hang-after-success (see bin/deploy-prod.ts header); killing it. ' +
+      'The smoke test is the real gate.',
+  )
+  proc.kill('SIGKILL')
+}, DEADLINE_MS)
+
+const exitCode = await proc.exited
+clearTimeout(timer)
+
+if (timedOut) {
+  process.exit(0)
+}
+if (exitCode !== 0) {
+  console.error(`alchemy deploy failed with exit code ${exitCode}`)
+  process.exit(exitCode)
+}

--- a/apps/f311x/bin/smoke-test.ts
+++ b/apps/f311x/bin/smoke-test.ts
@@ -1,0 +1,56 @@
+// Post-deploy gate: proves prod is serving a working production bundle
+// instead of trusting deploy exit codes (which the alchemy CLI's
+// hang-after-success makes unreliable — see bin/deploy-prod.ts).
+//
+// A page passes when its HTML references hashed client assets, does NOT
+// reference the Vite dev virtual entry (the 2026-06-11 incident: dev-mode
+// SSR bundles shipped `/@id/virtual:tanstack-start-dev-client-entry`, which
+// 404s in production so the page never hydrates), and its client JS entry
+// actually serves. Each URL gets a few attempts to ride out propagation.
+
+const DEV_ENTRY = 'virtual:tanstack-start-dev-client-entry'
+const ATTEMPTS = Number(process.env.SMOKE_ATTEMPTS ?? 6)
+const RETRY_DELAY_MS = Number(process.env.SMOKE_RETRY_DELAY_MS ?? 10_000)
+const urls = (
+  process.env.SMOKE_URLS ??
+  'https://f311x-website-prod-ddptpca6nyzpodvc.nullserve.workers.dev/,https://f311x.com/'
+).split(',')
+
+const failures: string[] = []
+
+async function check(url: string): Promise<string | null> {
+  const page = await fetch(url, {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `HTTP ${page.status}`
+  const html = await page.text()
+  if (html.includes(DEV_ENTRY)) return 'serves a dev-mode bundle (dev virtual entry present)'
+  const entry = html.match(/src="(\/assets\/[^"]+\.js)"/)?.[1]
+  if (!entry) return 'no hashed client JS entry in HTML'
+  const asset = await fetch(new URL(entry, url), {signal: AbortSignal.timeout(15_000)})
+  if (!asset.ok) return `client entry ${entry} -> HTTP ${asset.status}`
+  return null
+}
+
+for (const url of urls) {
+  let lastProblem = 'unreachable'
+  let passed = false
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    try {
+      const problem = await check(url)
+      if (problem === null) {
+        console.log(`OK: ${url} serves a production bundle`)
+        passed = true
+        break
+      }
+      lastProblem = problem
+    } catch (err) {
+      lastProblem = err instanceof Error ? err.message : String(err)
+    }
+    if (attempt < ATTEMPTS) await Bun.sleep(RETRY_DELAY_MS)
+  }
+  if (!passed) failures.push(`${url}: ${lastProblem}`)
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) console.error(`::error::smoke test failed — ${failure}`)
+  process.exit(1)
+}

--- a/apps/f311x/mise.toml
+++ b/apps/f311x/mise.toml
@@ -1,6 +1,11 @@
 # Canonical check tasks for this app. CI and automation discover checks here;
 # tasks delegate to package.json scripts. Assumes `pnpm install` has run.
 
+# bun runs the deploy/smoke scripts in bin/ (repo rule: scripts are bun, not
+# bash); the app itself stays on the Node/pnpm toolchain.
+[tools]
+bun = "1"
+
 [tasks.typecheck]
 description = "Type-check with tsgo"
 run = "pnpm run typecheck"

--- a/apps/f311x/package.json
+++ b/apps/f311x/package.json
@@ -57,6 +57,7 @@
     "@tanstack/devtools-vite": "latest",
     "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.2",
+    "@types/bun": "1.3.14",
     "@types/node": "25.9.1",
     "@types/react": "19.2.16",
     "@types/react-dom": "19.2.3",

--- a/apps/f311x/pnpm-lock.yaml
+++ b/apps/f311x/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@testing-library/react':
         specifier: 16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/node':
         specifier: 25.9.1
         version: 25.9.1
@@ -131,7 +134,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       '@typescript/native-preview':
         specifier: latest
-        version: 7.0.0-dev.20260607.1
+        version: 7.0.0-dev.20260611.2
       '@vitejs/plugin-react':
         specifier: 6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -2735,6 +2738,9 @@ packages:
   '@types/aws-lambda@8.10.162':
     resolution: {integrity: sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -2788,50 +2794,50 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260607.1':
-    resolution: {integrity: sha512-7t6tPrvxiHTCL8Ye8H/XZDceUB/UTXerghIEBiVjoEvPK6AYxxqOB0vEhKGRhlCkUd3kQAcKQuda/SK63hBkTQ==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-X6NqNmoTnO1vtcsE4qP571BByPi+i16Ynrp6fffcQ38pbRuy4mwECxA9nKb273gscG0wvcIcGM81B+vy1F4nDw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260607.1':
-    resolution: {integrity: sha512-pCzBIEDQTDaXdGdv6tQkPdnvnyLdIhSApeTjP86rvm3bfNpMbSi0DkDSQoJvEeZWYDw0ewe7TTDhbgtTSmqegQ==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-VeguHC/F7EbxNPCrcwCRH2wif6PZKcdUg2DtMyjxohtcVK3vOoVCYqhJBgJVWQ2gbXk+bXcIz8L2/uNYDksN0w==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260607.1':
-    resolution: {integrity: sha512-OAJi5GpueqRVGrtDn/N8uNRriD1OX1jvJf3GyYNMKdWw4ZAArYKAmLU0ZY4rEDj4oIV2RAHf1IGVQesCBcWqIw==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-19TXmRxxPUNNDAP/4xBwDNud1NvuNgQJhRm87t7/CSh4FGhWeeEm7AuyEvrCB+vzeeI/ExT+J58U1HOo+kYKzg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260607.1':
-    resolution: {integrity: sha512-8cFWEOlCcVh8pPiqkXkjgNqPJgOk3VLtYKijMh9KAPaDFu3EBfV9pp68uteTajljPmZdX5zYkfcMzQly2RjMzg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-szcSb7sSn3OQZ5UWtToG2RTQeDlokd05pXM+rGctBIctDj6E4j9bvAfp6xLZCzqyDuZJhi3cXCJBdSlBD0NjHw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260607.1':
-    resolution: {integrity: sha512-TGdfapfCFj4hl9M1/5oG6wjjhfoFviiMLru3a7ib63ozQwMDraJNqPrJuQ0tvVAoSMJb1wtVbvg7yYMml/KPLg==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-h5Etd2Kc6lvvc+X4MU/EFeYDUZAS4hOqB18piWuy2INHfRvJMOo8jZOwUJRix3NQu75tPbltFCkwFOGqB0fd2Q==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260607.1':
-    resolution: {integrity: sha512-tOEn/EC0nRnz7JHfDWwXmmBkU4dt8wdU/jYyJTOlkEhxfJtAJTjVmo4AUHwzLyV9KGIzvfymTKrQPTnD0p9ACA==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-JUUFHNi3asye8iOlVmFEra34LuQ8bw8qvYWp+cW7EXg3mrMxtac/u5chhi8BmICEav2Ff3UFd8ZFL0n+F5EvBA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260607.1':
-    resolution: {integrity: sha512-SBWFFs+MglgDrx8lh37uFHVQcljN09Z/D8Z+YwykMVKtYEIGM/i5WzS8Xpiegm9Vcqu3HTkuAfjQfy6X5MsqnA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-1ZPtOctecgkUHBIEoTefE34t4CewqxwdzIkRx22fDEC9bHhN8xO4JSfQyL+OSWDxiZaJKuqR9BnfWSl2eAFtmg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260607.1':
-    resolution: {integrity: sha512-+DBR9iyRZiUNhJI2CqFluJLxKl3xkBGFFCADiy63pCpLVCCNuffunRhcxQ2vhnLnM3dBDoqOHE4ekKg0GfaS/Q==}
+  '@typescript/native-preview@7.0.0-dev.20260611.2':
+    resolution: {integrity: sha512-nP/OrQRFTRKHeQiXzMVhQlxSrOPeuDgeGGd9KMlmOFTc/bbQ8Zd6Ep5izsdTkFljd26QUfpm98crp5E5bYAvJg==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -3031,6 +3037,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -7955,6 +7964,10 @@ snapshots:
 
   '@types/aws-lambda@8.10.162': {}
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -8010,36 +8023,36 @@ snapshots:
     dependencies:
       '@types/node': 25.9.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260607.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260611.2':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260607.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260611.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260607.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260611.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260607.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260611.2':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260607.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260611.2':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260607.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260611.2':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260607.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260611.2':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260607.1':
+  '@typescript/native-preview@7.0.0-dev.20260611.2':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260607.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260607.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260607.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260607.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260607.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260607.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260607.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260611.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260611.2
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -8256,6 +8269,10 @@ snapshots:
       electron-to-chromium: 1.5.368
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.9.1
 
   bundle-name@4.1.0:
     dependencies:

--- a/apps/f311x/vite.config.ts
+++ b/apps/f311x/vite.config.ts
@@ -11,13 +11,19 @@ const WORKERS_VIRTUALS = ['cloudflare:workers', /^cloudflare:/]
 
 const config = defineConfig({
   resolve: {tsconfigPaths: true},
+  // Key order matters: alchemy's cloudflare vite plugin replaces TanStack
+  // Start's buildApp with a naive loop over Object.values(environments), so
+  // whichever environment is declared first builds first. The client build
+  // must precede ssr or the start manifest falls back to the dev client
+  // entry (/@id/virtual:tanstack-start-dev-client-entry) and the deployed
+  // page never hydrates. See the 2026-06-11 progress note.
   environments: {
-    ssr: {
+    client: {
       build: {
         rollupOptions: {external: WORKERS_VIRTUALS},
       },
     },
-    client: {
+    ssr: {
       build: {
         rollupOptions: {external: WORKERS_VIRTUALS},
       },

--- a/docs/projects/f311x/2026-06-11-progress.md
+++ b/docs/projects/f311x/2026-06-11-progress.md
@@ -173,11 +173,45 @@ Two consequences:
   loudly if the store is absent or outdated — and stays unwrapped so
   genuine deploy failures keep failing the run.
 
+## Root cause of the runtime error, pinned (2026-06-12)
+
+Pulled the deployed prod worker's bundle (2 MB) and compared against the
+production build. The dev-mode artifact ships **TanStack Devtools'
+`EventClient`**: its first `emit()` while disconnected calls
+`#connectFunction()` + `startConnectLoop()` — a connection attempt plus
+`setInterval` — in Workers startup scope. That is verbatim the
+`Disallowed operation called within global scope` error David saw; it
+aborts SSR (the `<!--$!-->` errored-Suspense marker in the live HTML).
+The production bundle contains zero devtools code (`EventClient` /
+`tanstack-connect` / `setInterval` all absent from `dist/server`).
+
+## Local deploy incident (2026-06-12) — domains stolen by the dev stage
+
+David ran a local `alchemy deploy` (default stage `dev_davidfelix`). It
+uploaded a fresh dev-stage bundle, **attached f311x.com / www to the dev
+worker** (so the domain binding works — no zone-scope problem with his
+credentials), and then hung — the deploy command has the same
+hang-after-success bug as bootstrap. Consequences and fixes:
+
+- f311x.com now SSRs (chat echo streams in prod!) but doesn't hydrate:
+  dev-stage builds reference the dev virtual client entry, which 404s.
+- `alchemy.run.ts`: the `domain` binding is now **prod-stage-only** (props
+  are an Effect reading `Alchemy.Stage`), so dev deploys can't take the
+  public domains again. Typechecked + CLI-load verified.
+- `cd-deploy-f311x.yml`: deploy step capped at 10 min tolerating only the
+  timeout exit code (real failures still fail), plus a **smoke test** step
+  that fails unless the workers.dev URL and f311x.com both serve a
+  production bundle (hashed assets, no dev virtual entry). The smoke logic
+  was tested against the broken artifacts (fails) and the production build
+  (passes). The prod deploy re-claims the domains from the dev worker via
+  Cloudflare's hostname upsert; alchemy reconciles domain ownership against
+  live state, so later dev deploys won't detach prod's domains.
+
 ## Blockers or open questions
 
-- The `F311X_CLOUDFLARE_API_TOKEN` scopes can't be inspected from this
-  environment; whether domain-attach needs **Zone · DNS · Edit** /
-  **Zone · Workers Routes · Edit** is unverified until the next deploy runs.
+- ~~Whether domain-attach needs a zone scope~~ — resolved: domains attached
+  fine (via David's local credentials; the CI token gets its proof on the
+  next prod deploy).
 - Deploy failures were silent for three days — no notification gates them.
-  The preview-deployments project (post-deploy smoke test) closes this; until
-  then, the CD workflow's status is worth a glance after any f311x merge.
+  The CD smoke test now fails the run when prod serves a bad bundle; the
+  preview-deployments project extends this to per-PR previews.

--- a/docs/projects/f311x/2026-06-11-progress.md
+++ b/docs/projects/f311x/2026-06-11-progress.md
@@ -154,6 +154,25 @@ auth token, no prompts; when the store exists and is current it only
 refreshes credentials, and when it is outdated it upgrades it — so the
 step is idempotent and self-heals future alchemy version bumps.
 
+## Post-merge deploy failure 2 — bootstrap succeeds, CLI never exits
+
+Run 27387217212 (the #225 merge): bootstrap **did its job in 14 seconds** —
+upgraded the state store v6 → v7, uploaded the worker, printed
+`Done: 2 succeeded` at 00:52:30 — then the CLI process never exited
+(orphaned node children in the runner cleanup; no prompt in the output).
+The job's 15-minute timeout cancelled it before the deploy step ran.
+
+Two consequences:
+
+- **The state-store upgrade is durable** — the account's store is now v7,
+  so the deploy's own state check passes from here on with no bootstrap.
+- The bootstrap step is now **manual-only**: it runs only when the workflow
+  is dispatched with `bootstrap: true` (needed again only when an alchemy
+  bump changes the store version), capped with `timeout -k 10s 180s … ||
+  true` because of the hang. The deploy step is the real gate — it fails
+  loudly if the store is absent or outdated — and stays unwrapped so
+  genuine deploy failures keep failing the run.
+
 ## Blockers or open questions
 
 - The `F311X_CLOUDFLARE_API_TOKEN` scopes can't be inspected from this


### PR DESCRIPTION
## Summary

This PR now contains **the actual fix** for why f311x has never worked in production, plus the CD hardening from tonight's incident chain.

### The root cause (every alchemy-deployed artifact was broken)

Alchemy's cloudflare vite plugin (`@distilled.cloud/cloudflare-rolldown-plugin`'s options plugin) **replaces TanStack Start's `buildApp` with a naive loop** over `Object.values(app.environments)` — environments build in declaration order. Our `vite.config.ts` declared `ssr` before `client`, so the SSR build ran with no client manifest and TanStack Start's start-manifest fell back to the **dev client entry** (`/@id/virtual:tanstack-start-dev-client-entry`), which 404s in production: SSR renders, page never hydrates. Plain `vite build` was unaffected (TanStack Start's own `buildApp` builds client first), which is why local builds always looked fine.

**Fix**: declare `client` before `ssr` (with a comment explaining why order matters).

**Verification** (no credentials needed — alchemy's `viteBuild` invoked directly, the exact deploy code path):
- Before swap: server bundle has 2 dev-entry refs, builds `ssr → client`.
- After swap: builds `client → ssr`, **zero** dev-entry refs.
- The artifact served under workerd: full SSR render (no `<!--$!-->` errored-Suspense marker), hashed client entry returns 200, chat echo streams, zero errors in the workerd log.
- `vitest` 15/15, typecheck, plain `vite build` all green.

### CD hardening (from earlier tonight)

- **Bootstrap manual-only** (`workflow_dispatch` + `bootstrap: true`): run 27387217212 proved it works (store v6 → v7, durable) and that the beta.54 CLI hangs after success. Capped + tolerated; the deploy step is the real gate.
- **Domains prod-stage-only** (`alchemy.run.ts` reads `Alchemy.Stage`): a default-stage local deploy attached f311x.com/www to the dev worker; this prevents recurrence.
- **Deploy step capped at 10 min tolerating only exit 124** (the hang), with a **smoke test** that fails the run unless both the workers.dev URL and f311x.com serve a production bundle (hashed assets, no dev virtual entry). Predicate tested against the broken artifacts (fails) and the fixed build (passes).

### Remaining manual step before/after merge

f311x.com and www.f311x.com are currently attached to the **dev** worker, and alchemy refuses to steal hostnames (`Cannot attach hostname … already attached`). Either detach both in the dashboard (dev worker → Settings → Domains & Routes), or run a dev-stage deploy from this branch (`pnpm exec alchemy deploy --yes` — with prod-only domains, alchemy detaches them from the dev worker since its state tracks them), then deploy prod.

Related: #220, #221, #225 · Upstream class of devtools bug: [TanStack/ai#667](https://github.com/TanStack/ai/issues/667)

https://claude.ai/code/session_017S5jRTLaWninjiWBqgqnT2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deploy path, public domain binding, and build order for the live site; mitigated by prod-only domains and post-deploy smoke checks.
> 
> **Overview**
> Fixes **broken production hydration** by declaring the Vite **`client` environment before `ssr`** in `vite.config.ts`, so Alchemy’s build order produces a real client manifest instead of the dev virtual entry that 404s in prod.
> 
> **CD hardening:** `alchemy.run.ts` binds **custom domains only on the `prod` stage** so local/dev deploys cannot attach `f311x.com` / `www`. The deploy workflow runs **`bin/deploy-prod.ts`** (10‑minute cap + kill on Alchemy CLI hang-after-success) and **`bin/smoke-test.ts`** as the real gate (hashed assets, no dev entry, client JS 200). State-store **bootstrap is manual** via `workflow_dispatch` + `bootstrap: true`, with a capped run and tolerated exit. **Bun** is added for those `bin/` scripts (`mise.toml`, `@types/bun`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73da45e8eec8929de016198d85960fe0bececc57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->