### PR TITLE
fix(f311x): declare bun in the root mise config so CD can run it

### DIFF
--- a/.config/mise.lock
+++ b/.config/mise.lock
@@ -78,6 +78,54 @@ checksum = "sha256:1247239dae8f57aafeaeb9914e30b92efcc51c632eee3be4463a95969558f
 url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.16/biome-win32-x64.exe"
 provenance = "github-attestations"
 
+[[tools.bun]]
+version = "1.3.14"
+backend = "core:bun"
+
+[tools.bun."platforms.linux-arm64"]
+checksum = "sha256:a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64.zip"
+
+[tools.bun."platforms.linux-arm64-musl"]
+checksum = "sha256:b98e0ad3625c5c00d1d5b5ff55605c7adddbfae151861e68ade57b2d3b8703bb"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64-musl.zip"
+
+[tools.bun."platforms.linux-x64"]
+checksum = "sha256:951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip"
+
+[tools.bun."platforms.linux-x64-baseline"]
+checksum = "sha256:a063908ae08b7852ca10939bbdc6ceed3ddabce8fb9402dce83d65d73b36e6c7"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64-baseline.zip"
+
+[tools.bun."platforms.linux-x64-musl"]
+checksum = "sha256:14bd9aedeebf1dba67e8def9531c89bc989ecfdf1de42e5bfcaf1b8cd9294719"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64-musl.zip"
+
+[tools.bun."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:56a7d6806cf155536c0178f0ea5fbd098e684fa509ebdb4fc0a7e19fb65382dc"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64-musl-baseline.zip"
+
+[tools.bun."platforms.macos-arm64"]
+checksum = "sha256:d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-aarch64.zip"
+
+[tools.bun."platforms.macos-x64"]
+checksum = "sha256:4183df3374623e5bab315c547cfa0974533cd457d86b73b639f7a87974cd6633"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-x64.zip"
+
+[tools.bun."platforms.macos-x64-baseline"]
+checksum = "sha256:3e35ad6f53971a9834bf9e6786e2adf72b5f1921cc9a9c5fde073d2972944076"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-x64-baseline.zip"
+
+[tools.bun."platforms.windows-x64"]
+checksum = "sha256:0a0620930b6675d7ba440e81f4e0e00d3cfbe096c4b140d3fff02205e9e18922"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64.zip"
+
+[tools.bun."platforms.windows-x64-baseline"]
+checksum = "sha256:538f9c846355d9e847b2671bc00c47da4229a0befb24df3282b739770f3b475f"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64-baseline.zip"
+
 [[tools.ghalint]]
 version = "1.5.6"
 backend = "aqua:suzuki-shunsuke/ghalint"

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -1,6 +1,10 @@
 [tools]
 node = "26"
 pnpm = "11"
+# bun runs the deploy/smoke scripts in apps/*/bin (repo rule: scripts are
+# bun, not bash). Declared here because CI's `mise install` runs at the repo
+# root and does not read app-level mise.toml [tools].
+bun = "1"
 biome = "2"
 oxlint = "1"
 prettier = "3"

--- a/apps/f311x/mise.toml
+++ b/apps/f311x/mise.toml
@@ -1,10 +1,7 @@
 # Canonical check tasks for this app. CI and automation discover checks here;
 # tasks delegate to package.json scripts. Assumes `pnpm install` has run.
-
-# bun runs the deploy/smoke scripts in bin/ (repo rule: scripts are bun, not
-# bash); the app itself stays on the Node/pnpm toolchain.
-[tools]
-bun = "1"
+# bun (for the bin/ deploy and smoke scripts) is declared in the repo-root
+# .config/mise.toml: CI's `mise install` only reads the root config.
 
 [tasks.typecheck]
 description = "Type-check with tsgo"


### PR DESCRIPTION
## Summary

The post-merge CD run from #227 failed at the deploy step with `bun: command not found`.

**Why**: `jdx/mise-action` runs `mise install` at the repository root, which reads only `.config/mise.toml`. The `[tools] bun = "1"` I added to `apps/f311x/mise.toml` in #227 is never seen by that install — the failing run's PATH is the proof: every root-declared tool is present (`node`, `pnpm`, `biome`, `oxlint`, `prettier`, `actionlint`, `ghalint`, `zizmor`, `pinact`), bun is not.

## Changes

- Declare `bun = "1"` in the root `.config/mise.toml` `[tools]` table — the same place every other CI tool lives — with a comment explaining why it must be root-level.
- Drop the ineffective app-level `[tools]` block from `apps/f311x/mise.toml`, leaving a pointer comment.

Both TOML files validated. The commit touches `apps/f311x/**`, so merging this re-triggers **CD Deploy f311x** automatically — no manual dispatch needed.

## What to expect from the deploy this triggers

bootstrap skipped (push event) → `bun bin/deploy-prod.ts` runs the real deploy with the client-before-ssr build fix → `bun bin/smoke-test.ts` gates the run. Reminder: f311x.com/www are still attached to the **dev** worker; if they haven't been detached yet, the deploy step will fail on the domain attach (alchemy refuses to steal hostnames) — detach in the dash (`f311x-website-dev-…` → Settings → Domains & Routes) and re-run the workflow.

Related: #220, #227

https://claude.ai/code/session_017S5jRTLaWninjiWBqgqnT2

---
_Generated by [Claude Code](https://claude.ai/code/session_017S5jRTLaWninjiWBqgqnT2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change to mise config and lockfile; no application or auth logic is modified.
> 
> **Overview**
> Moves **bun** from `apps/f311x/mise.toml` into the repo-root `.config/mise.toml` `[tools]` table so CI’s root-level `mise install` actually puts `bun` on `PATH` for f311x CD steps (`bun bin/deploy-prod.ts`, `bun bin/smoke-test.ts`).
> 
> Adds a short comment at the root explaining why bun must live there, replaces the app-level `[tools]` block with a pointer comment, and extends `.config/mise.lock` with pinned **bun 1.3.14** across platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f374a66114f42e6de6ff161d22cd3aaf6c2867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->