### PR TITLE
fix(repo): allow self-hosted Renovate to run `mise lock`

### DIFF
--- a/.github/workflows/cron-renovate.yml
+++ b/.github/workflows/cron-renovate.yml
@@ -63,3 +63,10 @@ jobs:
           # runs Renovate only against itself.
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_CUSTOM_ENV_VARIABLES: '{"MISE_YES":"1"}'
+          # Refreshing our mise.lock files means Renovate runs `mise lock`,
+          # which it treats as an "unsafe execution" (a dependency update
+          # could run arbitrary code). It's a self-hosted-only option, so it
+          # can't live in .github/renovate.json — it must be set here. Without
+          # it the dashboard warns "mise lock was requested to run, but mise
+          # is not permitted in the allowedUnsafeExecutions".
+          RENOVATE_ALLOWED_UNSAFE_EXECUTIONS: '["mise"]'

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -1,5 +1,17 @@
 # 2026-06
 
+## 2026-06-14
+
+### fix(repo): let self-hosted Renovate run `mise lock`
+
+The Renovate dependency dashboard was warning "mise lock was requested to run, but
+mise is not permitted in the allowedUnsafeExecutions". Renovate's mise manager wants
+to refresh our `mise.lock` files (`.config/mise.lock`, `Advent-of-Code/2023/mise.lock`)
+by running `mise lock`, which it classifies as an unsafe execution and blocks unless
+explicitly allowlisted. `allowedUnsafeExecutions` is a self-hosted-only option, so it
+can't go in `.github/renovate.json`; set `RENOVATE_ALLOWED_UNSAFE_EXECUTIONS='["mise"]'`
+in the `cron-renovate` workflow instead.
+
 ## 2026-06-13
 
 ### feat(pkg.dog): move from Vue SPA to Nuxt; settle type-checker policy


### PR DESCRIPTION
## Summary

Configure self-hosted Renovate to permit `mise lock` as an unsafe execution, allowing it to refresh `mise.lock` files without dashboard warnings.

## Changes

- Added `RENOVATE_ALLOWED_UNSAFE_EXECUTIONS` environment variable to the `cron-renovate` workflow, explicitly allowing `mise` as a safe unsafe execution
- Updated changelog with explanation of the fix

## Changelog entry

```markdown
### fix(repo): allow self-hosted Renovate to run `mise lock`

The Renovate dependency dashboard was warning "mise lock was requested to run, but
mise is not permitted in the allowedUnsafeExecutions". Renovate's mise manager wants
to refresh our `mise.lock` files (`.config/mise.lock`, `Advent-of-Code/2023/mise.lock`)
by running `mise lock`, which it classifies as an unsafe execution and blocks unless
explicitly allowlisted. `allowedUnsafeExecutions` is a self-hosted-only option, so it
can't go in `.github/renovate.json`; set `RENOVATE_ALLOWED_UNSAFE_EXECUTIONS='["mise"]'`
in the `cron-renovate` workflow instead.
```

## Testing

- [x] Builds successfully
- [x] No tests needed — configuration change only

https://claude.ai/code/session_01FMTAVPkYm6wLPEbA7256zZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow env-only change for the Renovate bot; no app runtime or auth paths affected.
> 
> **Overview**
> Self-hosted Renovate can refresh **`mise.lock`** files again without the dependency dashboard blocking **`mise lock`**.
> 
> The **`cron-renovate`** workflow now sets **`RENOVATE_ALLOWED_UNSAFE_EXECUTIONS='["mise"]'`** because Renovate treats **`mise lock`** as an unsafe execution and **`allowedUnsafeExecutions`** is self-hosted-only (it cannot live in **`.github/renovate.json`**). A **2026-06-14** changelog entry documents the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae6ab7fc7445350d1ef42d692aee20f2cab8b321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->