### PR TITLE
fix(f311x): restore production and harden smoke test

### DIFF
--- a/apps/f311x/bin/smoke-test.ts
+++ b/apps/f311x/bin/smoke-test.ts
@@ -6,7 +6,10 @@
 // reference the Vite dev virtual entry (the 2026-06-11 incident: dev-mode
 // SSR bundles shipped `/@id/virtual:tanstack-start-dev-client-entry`, which
 // 404s in production so the page never hydrates), and its client JS entry
-// actually serves. Each URL gets a few attempts to ride out propagation.
+// actually serves. It then POSTs to the chat endpoint and requires the echo
+// back as an AG-UI SSE stream, so a hydrated shell with a dead backend (the
+// other half of "deployed but broken") fails the gate too. Each URL gets a
+// few attempts to ride out propagation.
 
 const DEV_ENTRY = 'virtual:tanstack-start-dev-client-entry'
 const ATTEMPTS = Number(process.env.SMOKE_ATTEMPTS ?? 6)
@@ -27,6 +30,27 @@ async function check(url: string): Promise<string | null> {
   if (!entry) return 'no hashed client JS entry in HTML'
   const asset = await fetch(new URL(entry, url), {signal: AbortSignal.timeout(15_000)})
   if (!asset.ok) return `client entry ${entry} -> HTTP ${asset.status}`
+  return checkChat(url)
+}
+
+// The chat loop is the whole point of the app: a hydrated shell talking to a
+// dead backend is still broken. POST an AG-UI RunAgentInput and require the
+// echo stream back — lifecycle events plus the message echoed verbatim — so a
+// backend regression fails the gate, not just a broken client bundle.
+async function checkChat(url: string): Promise<string | null> {
+  const sentinel = `smoke-${Math.random().toString(36).slice(2, 8)}`
+  const res = await fetch(new URL('agents/chat-agent/default', url), {
+    method: 'POST',
+    headers: {'content-type': 'application/json', accept: 'text/event-stream'},
+    body: JSON.stringify({messages: [{role: 'user', content: sentinel}]}),
+    signal: AbortSignal.timeout(15_000),
+  })
+  if (!res.ok) return `chat endpoint -> HTTP ${res.status}`
+  const body = await res.text()
+  for (const marker of ['RUN_STARTED', 'TEXT_MESSAGE_CONTENT', 'RUN_FINISHED']) {
+    if (!body.includes(marker)) return `chat stream missing ${marker}`
+  }
+  if (!body.includes(sentinel)) return 'chat stream did not echo the message back'
   return null
 }
 

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -2,6 +2,20 @@
 
 ## 2026-06-14
 
+### fix(f311x): restore production — free domains from a leftover dev worker; smoke-test the chat loop
+
+f311x had been serving a non-hydrating dev-mode page since the 2026-06-06 deploy. #221
+(merged 2026-06-11) fixed the ingress, deploy-toolchain, and artifact bugs, but every prod
+deploy afterward still failed at custom-domain reconciliation: a leftover dev-stage worker
+(`f311x-website-dev-davidfelix-*`) still held `f311x.com` / `www.f311x.com`, and Cloudflare
+won't attach one hostname to two Workers. Detaching the two domains from that worker let the
+prod deploy (CD run 27504856773) claim ingress and ship the correct production bundle —
+f311x.com and www now hydrate and the chat echo streams end to end. The #220 token-scope
+worry was a red herring: the deploy authenticated fine and needed no zone scope. Also
+hardened `bin/smoke-test.ts` to POST the chat endpoint and require the AG-UI echo stream
+back, so a hydrated shell with a dead backend now fails the CD gate too (it previously
+checked only hydration).
+
 ### fix(repo): let self-hosted Renovate run `mise lock`
 
 The Renovate dependency dashboard was warning "mise lock was requested to run, but

--- a/docs/projects/f311x/2026-06-14-progress.md
+++ b/docs/projects/f311x/2026-06-14-progress.md
@@ -1,0 +1,65 @@
+# f311x — 2026-06-14 progress
+
+## Session summary
+
+Restored f311x production. PR #221 (merged 2026-06-11) fixed the ingress,
+deploy-toolchain, and dev-mode-artifact bugs, but every deploy afterward still
+failed and f311x.com still served the broken, non-hydrating dev-mode page.
+Found the remaining blocker, David cleared it, the redeploy went green, and the
+full loop (hydration + chat echo) is verified live. Also hardened the smoke
+test so it covers the chat backend, not just hydration.
+
+## Root cause (the part #221 couldn't fix from code)
+
+Every CD deploy from the #221 merge through 2026-06-14 failed at the same
+step — _Reconciling custom domains_:
+
+> Cannot attach hostname 'www.f311x.com' to Worker
+> 'f311x-website-prod-ddptpca6nyzpodvc': it is already attached to Worker
+> 'f311x-website-dev-davidfelix-izo744ti7e5bseua'.
+
+A leftover **dev-stage worker** still held `f311x.com` + `www.f311x.com`
+(claimed before the 2026-06-12 prod-only domain gate landed in
+`alchemy.run.ts`). Cloudflare won't attach one hostname to two Workers, so the
+prod deploy could never take ingress — and that dev worker, running a local
+dev-mode build, was what served the broken page at f311x.com the entire time.
+The HTTP 200 masked it: the shell painted, but its client entry
+(`/@id/virtual:tanstack-start-dev-client-entry`) 404s, so the app never
+hydrated.
+
+The token-scope worry tracked in #220 was a **red herring**: the deploy
+authenticated fine and got all the way to domain reconciliation. No zone scope
+was needed.
+
+## Work completed
+
+- Diagnosed the deploy failure from CI logs (CD run 27504856773, attempt 1).
+- David detached `f311x.com` + `www.f311x.com` from the dev worker and re-ran
+  CD Deploy f311x (run 27504856773, attempt 2 → success).
+- Verified live:
+  - `f311x.com` and `www.f311x.com` return 200 and serve a real production
+    bundle — hashed `/assets/index-DvOy9O6E.js` entry present and resolving,
+    no dev virtual entry.
+  - Chat echo streams: `RUN_STARTED → TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT
+    (×3) → TEXT_MESSAGE_END → RUN_FINISHED`, echoing the prompt back.
+- Hardened `bin/smoke-test.ts`: it now POSTs an AG-UI `RunAgentInput` to
+  `/agents/chat-agent/default` and requires the echo stream back (lifecycle
+  events + the message echoed verbatim). Previously it only checked hydration,
+  so a dead backend would have passed. Ran it green against live prod.
+
+## Decisions
+
+- Domains stay gated to the prod stage (already in `alchemy.run.ts`). David
+  detached only the domains; the stray dev worker was left in place.
+
+## Next steps
+
+- Swap the echo stub for a real model (next f311x plan item).
+- Optional cleanup: delete the stray `f311x-website-dev-*` worker entirely —
+  dev should be local `vite dev`, not a deployed worker. Left as-is for now.
+- Per-PR _preview_ deploy + smoke test is still open (preview-deployments
+  Phase 1); the post-deploy smoke test now covers hydration + chat.
+
+## Blockers / open questions
+
+- None for the restore.

--- a/docs/projects/f311x/plan.md
+++ b/docs/projects/f311x/plan.md
@@ -3,32 +3,24 @@
 A small chat app on Cloudflare — TanStack Start front end, deployed via Alchemy v2.
 "f311x" is the agent. Today it builds and deploys; the chat backend isn't wired yet.
 
-## Current state (2026-06-11)
+## Current state (2026-06-14)
 
-- **Diagnosed — three stacked failures, fixes in flight on `claude/relaxed-tesla-4bwmbj`:**
-  1. **No ingress**: `alchemy.run.ts` never set `domain`, so f311x.com has zero
-     DNS records and no custom domain is attached to the Worker. Fixed by
-     binding `f311x.com` / `www.f311x.com`.
-  2. **Every deploy since 2026-06-08 has failed.** #207 bumped alchemy
-     beta.45→51, which crashed the CLI at startup (effect `SchemaAST`
-     TypeError); #208's lockfile maintenance then removed
-     `@effect/platform-node` (an optional peer alchemy's `WorkerBridge.js`
-     imports unconditionally), changing the crash to `ERR_MODULE_NOT_FOUND`.
-     The echo backend (#211) never reached prod. Fixed: alchemy → beta.54 plus
-     an explicit `@effect/platform-node` devDependency pinned to effect's
-     version; the CLI now reaches Cloudflare auth cleanly. (beta.55 worked too
-     but is <24h old and pnpm's release-age policy rejects it in CI; pnpm
-     overrides pin the too-fresh transitives to ≥24h-old releases.)
-  3. **The artifact prod is serving is a dev-mode build** (the only successful
-     deploy, 2026-06-06, alchemy beta.45 + floating `@tanstack/react-start`).
-     Its SSR HTML references `/@id/virtual:tanstack-start-dev-client-entry`,
-     which 404s — page shell loads, app never hydrates. Verified the current
-     toolchain builds a correct production bundle (real hashed assets, echo
-     SSE works under workerd via `vite preview`). A fresh deploy replaces the
-     artifact.
-- One open risk: the deploy token may need a zone scope to attach the custom
-  domains — see the token-scopes section. Full details in the 2026-06-11
-  progress note.
+- **Production restored and verified.** `f311x.com` and `www.f311x.com` serve
+  a real production bundle that hydrates (hashed `/assets/index-*.js` entry
+  resolves; no dev virtual entry), and the chat echo streams end to end
+  (`RUN_STARTED → TEXT_MESSAGE_* → RUN_FINISHED`). Verified live after the
+  2026-06-14 deploy (CD run 27504856773).
+- **What had been wrong.** Three stacked failures — no ingress, a broken
+  deploy toolchain, and a dev-mode artifact — were fixed in #221 (merged
+  2026-06-11). One blocker outlived the merge: a leftover **dev-stage worker**
+  still held `f311x.com` / `www.f311x.com` (claimed before the prod-only
+  domain gate landed on 2026-06-12), so every prod deploy failed at custom-
+  domain reconciliation and the dev worker kept serving the broken page.
+  Detaching the domains from it (2026-06-14) let prod claim ingress. The #220
+  token-scope concern was a red herring — no zone scope was needed. Full
+  story: 2026-06-11 and 2026-06-14 progress notes.
+- **The smoke test now covers the chat loop**, not just hydration
+  (`bin/smoke-test.ts`), so "deployed but dead" fails the CD gate.
 
 ## Earlier state (2026-06-08)
 
@@ -59,18 +51,19 @@ Stabilize before building (reprioritized 2026-06-11).
 - [x] Diagnose why prod is broken; capture the symptom and root cause in a
       progress note. (2026-06-11: no ingress — no custom domain on the Worker,
       no DNS records in the zone. See the progress note.)
-- [ ] Restore prod: merge the fix branch (CD deploys on merge, or
-      `workflow_dispatch` re-runs it). The deploy rebuilds with the repaired
-      toolchain (replacing the dev-mode artifact) and attaches the custom
-      domains. Verify https://f311x.com loads, hydrates, and the chat echo
-      streams. May require granting the deploy token a zone scope first.
+- [x] Restore prod. #221 merged (2026-06-11); the remaining blocker was a
+      leftover dev worker holding the custom domains — detached 2026-06-14,
+      redeployed (CD run 27504856773), and verified f311x.com / www hydrate and
+      the chat echo streams. No zone scope was needed.
 - [ ] Make breakage readable: error visibility for the Worker (Cloudflare
       logs/tail and/or the f311x slice of
       [Sentry Integration](../sentry-integration/plan.md) pulled forward) so
       "why is it broken" doesn't require a local repro.
 - [ ] Make breakage visible pre-merge: per-PR preview deploy + smoke test —
       f311x is the first target of the
-      [preview-deployments](../preview-deployments/plan.md) project.
+      [preview-deployments](../preview-deployments/plan.md) project. (The
+      post-deploy smoke test now gates CD and covers hydration + the chat
+      stream; the per-PR *preview* deploy is still to do.)
 - [x] Wire the smallest agent backend the UI can talk to — an echo stub answers
       `/agents/chat-agent/default` and streams the reply as AG-UI SSE events
       (`RUN_STARTED` → `TEXT_MESSAGE_*` → `RUN_FINISHED`). Backed by
@@ -108,13 +101,17 @@ Stabilize before building (reprioritized 2026-06-11).
 Only **Secrets Store: Edit** was missing on the first run; the resource scopes were
 already granted. See the Alchemy CI/CD guide and the 2026-06-06 progress note.
 
-**Custom domains (unverified scope)**: attaching `f311x.com` / `www.f311x.com`
-to the Worker creates DNS records in the zone. Cloudflare doesn't document the
-exact token permission for `PUT /accounts/:id/workers/domains`; if the deploy
-fails with another generic `10000 "Authentication error"`, grant the token
-**Zone · Workers Routes · Edit** and/or **Zone · DNS · Edit** scoped to
-f311x.com. Note the f311x workflow uses its own `F311X_CLOUDFLARE_API_TOKEN`
-secret, not the shared `CLOUDFLARE_API_TOKEN` the wrangler apps use.
+**Custom domains (resolved 2026-06-14 — no extra scope needed)**: attaching
+`f311x.com` / `www.f311x.com` to the Worker creates DNS records in the zone.
+This turned out to need **no additional zone scope** — the 2026-06-14 prod
+deploy (CD run 27504856773) attached both domains and created DNS with the
+existing token; it authenticated cleanly and the only failure mode seen was a
+hostname collision with a leftover dev worker, never a `10000` auth error. If
+a future deploy ever does fail with a generic `10000 "Authentication error"`
+at the domain step, the thing to try is granting **Zone · Workers Routes ·
+Edit** and/or **Zone · DNS · Edit** scoped to f311x.com. The f311x workflow
+uses its own `F311X_CLOUDFLARE_API_TOKEN` secret, not the shared
+`CLOUDFLARE_API_TOKEN` the wrangler apps use.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

f311x production is now restored and verified live. A leftover dev-stage worker was holding the custom domains, blocking prod deploys; after detaching them, the prod deploy succeeded and f311x.com now serves a real production bundle that hydrates and streams the chat echo end-to-end. Also hardened the smoke test to verify the chat backend, not just hydration.

## Changes

- **docs/projects/f311x/plan.md**: Updated current state (2026-06-14) to reflect production restored, documented the root cause (leftover dev worker blocking domain attachment), and clarified that no zone scope was needed for the deploy token.
- **docs/projects/f311x/2026-06-14-progress.md**: New progress note capturing the session summary, root cause analysis, work completed (diagnosis, domain detachment, live verification, smoke test hardening), decisions, and next steps.
- **apps/f311x/bin/smoke-test.ts**: Extended the smoke test to POST to `/agents/chat-agent/default` with an AG-UI `RunAgentInput` and verify the echo stream returns the required lifecycle events (`RUN_STARTED`, `TEXT_MESSAGE_CONTENT`, `RUN_FINISHED`) and echoes the message back. This ensures a hydrated shell with a dead backend now fails the CD gate.
- **docs/changelog/2026-06.md**: Added changelog entry documenting the fix, the root cause, and the smoke test hardening.

## Changelog entry

```markdown
### fix(f311x): restore production — free domains from a leftover dev worker; smoke-test the chat loop

f311x had been serving a non-hydrating dev-mode page since the 2026-06-06 deploy. #221
(merged 2026-06-11) fixed the ingress, deploy-toolchain, and artifact bugs, but every prod
deploy afterward still failed at custom-domain reconciliation: a leftover dev-stage worker
(`f311x-website-dev-davidfelix-*`) still held `f311x.com` / `www.f311x.com`, and Cloudflare
won't attach one hostname to two Workers. Detaching the two domains from that worker let the
prod deploy (CD run 27504856773) claim ingress and ship the correct production bundle —
f311x.com and www now hydrate and the chat echo streams end to end. The #220 token-scope
worry was a red herring: the deploy authenticated fine and needed no zone scope. Also
hardened `bin/smoke-test.ts` to POST the chat endpoint and require the AG-UI echo stream
back, so a hydrated shell with a dead backend now fails the CD gate too (it previously
checked only hydration).
```

## Testing

- [x] Manually verified live: f311x.com and www.f311x.com hydrate and stream the chat echo end-to-end (RUN_STARTED → TEXT_MESSAGE_* → RUN_FINISHED).
- [x] Smoke test ran green against live prod with the new chat-loop verification.
- [x] CD run 27504856773 (attempt 2) succeeded after domain detachment.

https://claude.ai/code/session_0132QnH2bvSSt1NPGaLFPVPk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to the f311x deploy smoke gate and documentation; no production app runtime or auth paths are modified in this diff.
> 
> **Overview**
> Documents **f311x production restore** (2026-06-14): a leftover dev-stage worker still owned `f311x.com` / `www.f311x.com`, so prod CD kept failing at custom-domain reconciliation and the broken dev bundle stayed live until those hostnames were detached. Plan, changelog, and a new progress note capture that outcome and mark restore / token-scope items done.
> 
> **`bin/smoke-test.ts`** now runs **`checkChat`** after the existing hydration checks: it POSTs to `agents/chat-agent/default` with a random sentinel and requires AG-UI SSE markers (`RUN_STARTED`, `TEXT_MESSAGE_CONTENT`, `RUN_FINISHED`) plus an echo of the message, so a hydrated front end with a dead chat backend fails the CD gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a3d3e4f95312e9abc7dcb2bda30ab7fe045f632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->