### PR TITLE
chore(cd): add deploy workflows for five scaffolded sites

### DIFF
--- a/.github/workflows/cd-deploy-monicandavid-com.yml
+++ b/.github/workflows/cd-deploy-monicandavid-com.yml
@@ -1,0 +1,53 @@
+name: CD Deploy monicandavid.com
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/monicandavid.com/**'
+      - '.github/workflows/cd-deploy-monicandavid-com.yml'
+
+defaults:
+  run:
+    working-directory: apps/monicandavid.com
+
+jobs:
+  deploy:
+    name: wrangler deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: false
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      # `pnpm install` already runs `panda codegen` via the prepare script, but
+      # keep it explicit so the build does not depend on install side effects.
+      - name: panda codegen
+        run: pnpm exec panda codegen
+
+      # SvelteKit's adapter-cloudflare emits the Worker into .svelte-kit/cloudflare
+      # during `vite build`, so a plain `wrangler deploy` ships that output.
+      - name: vite build
+        run: pnpm exec vite build
+
+      - name: wrangler deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: apps/monicandavid.com

--- a/.github/workflows/cd-deploy-onvibes-org.yml
+++ b/.github/workflows/cd-deploy-onvibes-org.yml
@@ -1,0 +1,49 @@
+name: CD Deploy onvibes.org
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/onvibes.org/**'
+      - '.github/workflows/cd-deploy-onvibes-org.yml'
+
+defaults:
+  run:
+    working-directory: apps/onvibes.org
+
+jobs:
+  deploy:
+    name: wrangler deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: false
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: panda codegen
+        run: pnpm exec panda codegen
+
+      - name: astro build
+        run: pnpm exec astro build
+
+      - name: wrangler deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: apps/onvibes.org

--- a/.github/workflows/cd-deploy-pkg-dog.yml
+++ b/.github/workflows/cd-deploy-pkg-dog.yml
@@ -1,0 +1,53 @@
+name: CD Deploy pkg.dog
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/pkg.dog/**'
+      - '.github/workflows/cd-deploy-pkg-dog.yml'
+
+defaults:
+  run:
+    working-directory: apps/pkg.dog
+
+jobs:
+  deploy:
+    name: wrangler deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: false
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      # `pnpm install` already runs `panda codegen` via the prepare script, but
+      # keep it explicit so the build does not depend on install side effects.
+      - name: panda codegen
+        run: pnpm exec panda codegen
+
+      # Nuxt (Nitro cloudflare_module preset) emits .output/server/index.mjs and
+      # .output/public, so a plain `wrangler deploy` ships that output.
+      - name: nuxt build
+        run: pnpm exec nuxt build
+
+      - name: wrangler deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: apps/pkg.dog

--- a/.github/workflows/cd-deploy-revision-city.yml
+++ b/.github/workflows/cd-deploy-revision-city.yml
@@ -1,0 +1,54 @@
+name: CD Deploy revision.city
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/revision.city/**'
+      - '.github/workflows/cd-deploy-revision-city.yml'
+
+defaults:
+  run:
+    working-directory: apps/revision.city
+
+jobs:
+  deploy:
+    name: wrangler deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: false
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      # `pnpm install` already runs `panda codegen` via the prepare script, but
+      # keep it explicit so the build does not depend on install side effects.
+      - name: panda codegen
+        run: pnpm exec panda codegen
+
+      # The Cloudflare Vite plugin emits the resolved Worker config into dist/
+      # and a redirect in .wrangler/deploy/, so a plain `wrangler deploy` picks
+      # up the built output.
+      - name: vite build
+        run: pnpm exec vite build
+
+      - name: wrangler deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: apps/revision.city

--- a/.github/workflows/cd-deploy-startchi-com.yml
+++ b/.github/workflows/cd-deploy-startchi-com.yml
@@ -1,0 +1,54 @@
+name: CD Deploy startchi.com
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/startchi.com/**'
+      - '.github/workflows/cd-deploy-startchi-com.yml'
+
+defaults:
+  run:
+    working-directory: apps/startchi.com
+
+jobs:
+  deploy:
+    name: wrangler deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: false
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      # `pnpm install` already runs `panda codegen` via the prepare script, but
+      # keep it explicit so the build does not depend on install side effects.
+      - name: panda codegen
+        run: pnpm exec panda codegen
+
+      # The Cloudflare Vite plugin emits the resolved Worker config into dist/
+      # and a redirect in .wrangler/deploy/, so a plain `wrangler deploy` picks
+      # up the built output.
+      - name: vite build
+        run: pnpm exec vite build
+
+      - name: wrangler deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: apps/startchi.com

--- a/docs/projects/new-domain-sites/2026-06-14-progress.md
+++ b/docs/projects/new-domain-sites/2026-06-14-progress.md
@@ -1,0 +1,33 @@
+# 2026-06-14 — CD workflows for the scaffolded sites
+
+## Done
+
+- Added `cd-deploy-*` GitHub Actions workflows for the five scaffolded sites that
+  had CI but no deploy job, so each ships to its `workers.dev` URL on push to
+  `main`:
+  - `onvibes.org` (Astro) — `panda codegen` + `astro build`
+  - `revision.city` (TanStack Start) — `panda codegen` + `vite build`
+  - `startchi.com` (TanStack Start) — `panda codegen` + `vite build`
+  - `monicandavid.com` (SvelteKit) — `panda codegen` + `vite build`
+    (`adapter-cloudflare` emits the worker into `.svelte-kit/cloudflare`)
+  - `pkg.dog` (Nuxt) — `panda codegen` + `nuxt build`
+    (Nitro `cloudflare_module` preset emits `.output/server/index.mjs` + `.output/public`)
+- Each workflow mirrors the existing CD template: pinned actions, mise, frozen
+  `pnpm install`, then `wrangler deploy` via the `CLOUDFLARE_API_TOKEN` /
+  `CLOUDFLARE_ACCOUNT_ID` secrets. Triggers are path-filtered to the app dir plus
+  the workflow's own file.
+
+## Notes
+
+- Verified the full set: every app's CI and CD workflow already triggers only on
+  path changes, so no CI changes were needed.
+- The six previously-deployed apps (djf.io, davidjfelix.com, calendar-visualizer,
+  ravrun, forzamonica.com, f311x) already had CD; this closes the gap for the rest.
+- Minor pre-existing inconsistency left untouched: `ci-f311x.yml` and
+  `ci-forzamonica-com.yml` list their `cd-deploy-*` file in their CI path filters,
+  while the other apps' CI workflows do not. Worth standardizing one way later.
+
+## Next
+
+- Confirm the first deploy of each site is green after this lands on `main`.
+- Custom-domain wiring per site when the Cloudflare zones are connected.

--- a/docs/projects/new-domain-sites/plan.md
+++ b/docs/projects/new-domain-sites/plan.md
@@ -28,8 +28,10 @@ alternative would be bare `tsc`. So: Astro → `astro check`, SvelteKit →
 `svelte-check`, Nuxt → `nuxt typecheck` (vue-tsc), and the TanStack Start / React
 apps → tsgo (no framework-specific checker; the alternative there is plain tsc).
 
-No CD workflows or custom-domain routes yet — wrangler configs serve from workers.dev
-once a deploy workflow exists.
+Every app now has a `cd-deploy-*` workflow that ships to its workers.dev URL on
+push to `main` (path-filtered to the app dir + its own workflow file). Custom-domain
+routes are not wired yet — the `routes` blocks in each `wrangler.toml` stay commented
+until the zones are connected.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Added CD (continuous deployment) workflows for the five scaffolded sites that had CI but no deploy job. Each site now automatically deploys to its `workers.dev` URL on push to `main`.

## Changes

- Added `cd-deploy-onvibes-org.yml` (Astro) — `panda codegen` + `astro build`
- Added `cd-deploy-revision-city.yml` (TanStack Start) — `panda codegen` + `vite build`
- Added `cd-deploy-startchi-com.yml` (TanStack Start) — `panda codegen` + `vite build`
- Added `cd-deploy-monicandavid-com.yml` (SvelteKit) — `panda codegen` + `vite build`
- Added `cd-deploy-pkg-dog.yml` (Nuxt) — `panda codegen` + `nuxt build`
- Each workflow uses pinned action versions, `mise` for tooling, frozen `pnpm install`, and `wrangler deploy` with Cloudflare secrets
- Path filters on each workflow trigger only on changes to the app directory or the workflow file itself
- Updated `docs/projects/new-domain-sites/plan.md` to reflect that CD workflows are now in place
- Added progress note at `docs/projects/new-domain-sites/2026-06-14-progress.md`

## Changelog entry

```markdown
### chore(cd): add deploy workflows for five scaffolded sites

Added `cd-deploy-*` GitHub Actions workflows for onvibes.org, revision.city, startchi.com, monicandavid.com, and pkg.dog. Each site now deploys to its `workers.dev` URL on push to `main`, with path-filtered triggers and framework-specific build steps (Astro, Vite, SvelteKit, Nuxt).
```

## Testing

- [x] Builds successfully
- [x] Workflows are syntactically valid (GitHub Actions YAML)
- [x] Path filters and triggers are correctly configured per app
- [ ] Manually verified (first deploy of each site after merge to `main`)

https://claude.ai/code/session_01TB4X8fsDPyMUsyG88Lqkka

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Merging enables automatic production deploys to Cloudflare using shared API secrets; failures or misconfigured builds could publish broken workers, though the pattern matches existing CD workflows.
> 
> **Overview**
> Adds **five path-filtered `cd-deploy-*` GitHub Actions workflows** so pushes to `main` automatically build and **`wrangler deploy`** the sites that previously had CI only: **onvibes.org**, **revision.city**, **startchi.com**, **monicandavid.com**, and **pkg.dog**.
> 
> Each job follows the existing CD pattern (pinned checkout/mise/wrangler-action, frozen `pnpm install`, `contents: read` / `deployments: write`) and differs only in the **framework build step**: Astro (`astro build`), TanStack Start sites (`panda codegen` + `vite build`), SvelteKit (`panda codegen` + `vite build`), and Nuxt (`panda codegen` + `nuxt build`). Deploys target each app’s **`workers.dev`** URL via shared **`CLOUDFLARE_API_TOKEN`** / **`CLOUDFLARE_ACCOUNT_ID`** secrets.
> 
> **Docs** now state that every new-domain app has CD on `main`; a **2026-06-14 progress note** records the rollout and follow-ups (first green deploys, custom domains later).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a3bfe07e3fbc3d451be681a7300d202d95552e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->