### PR TITLE
feat(apps): enable custom domain routes for the scaffolded sites

### DIFF
--- a/apps/monicandavid.com/wrangler.toml
+++ b/apps/monicandavid.com/wrangler.toml
@@ -4,12 +4,11 @@ main = ".svelte-kit/cloudflare/_worker.js"
 compatibility_date = "2026-06-01"
 compatibility_flags = ["nodejs_compat"]
 
-# monicandavid.com is not wired to the worker yet, so it serves from its
-# workers.dev URL. Once the zone is connected, add:
-# routes = [
-#   { pattern = "monicandavid.com", custom_domain = true },
-#   { pattern = "www.monicandavid.com", custom_domain = true },
-# ]
+# Custom domains, wired up in the Cloudflare dashboard.
+routes = [
+  { pattern = "monicandavid.com", custom_domain = true },
+  { pattern = "www.monicandavid.com", custom_domain = true },
+]
 
 [observability]
 enabled = true

--- a/apps/onvibes.org/wrangler.toml
+++ b/apps/onvibes.org/wrangler.toml
@@ -2,12 +2,11 @@
 name = "onvibes-org"
 compatibility_date = "2026-06-01"
 
-# onvibes.org is not wired to the worker yet, so it serves from its workers.dev
-# URL. Once the zone is connected, add:
-# routes = [
-#   { pattern = "onvibes.org", custom_domain = true },
-#   { pattern = "www.onvibes.org", custom_domain = true },
-# ]
+# Custom domains, wired up in the Cloudflare dashboard.
+routes = [
+  { pattern = "onvibes.org", custom_domain = true },
+  { pattern = "www.onvibes.org", custom_domain = true },
+]
 
 [assets]
 directory = "./dist"

--- a/apps/pkg.dog/wrangler.toml
+++ b/apps/pkg.dog/wrangler.toml
@@ -4,13 +4,12 @@ main = "./.output/server/index.mjs"
 compatibility_date = "2026-06-01"
 compatibility_flags = ["nodejs_compat"]
 
-# pkg.dog / pkgdog.com are not wired to the worker yet, so it serves from its
-# workers.dev URL. Once the zones are connected, add:
-# routes = [
-#   { pattern = "pkg.dog", custom_domain = true },
-#   { pattern = "pkgdog.com", custom_domain = true },
-#   { pattern = "www.pkgdog.com", custom_domain = true },
-# ]
+# Custom domains, wired up in the Cloudflare dashboard.
+routes = [
+  { pattern = "pkg.dog", custom_domain = true },
+  { pattern = "pkgdog.com", custom_domain = true },
+  { pattern = "www.pkgdog.com", custom_domain = true },
+]
 
 [observability]
 enabled = true

--- a/apps/pkg.dog/wrangler.toml
+++ b/apps/pkg.dog/wrangler.toml
@@ -7,6 +7,7 @@ compatibility_flags = ["nodejs_compat"]
 # Custom domains, wired up in the Cloudflare dashboard.
 routes = [
   { pattern = "pkg.dog", custom_domain = true },
+  { pattern = "www.pkg.dog", custom_domain = true },
   { pattern = "pkgdog.com", custom_domain = true },
   { pattern = "www.pkgdog.com", custom_domain = true },
 ]

--- a/apps/revision.city/wrangler.toml
+++ b/apps/revision.city/wrangler.toml
@@ -4,12 +4,11 @@ main = "@tanstack/react-start/server-entry"
 compatibility_date = "2026-06-01"
 compatibility_flags = ["nodejs_compat"]
 
-# revision.city is not wired to the worker yet, so it serves from its
-# workers.dev URL. Once the zone is connected, add:
-# routes = [
-#   { pattern = "revision.city", custom_domain = true },
-#   { pattern = "www.revision.city", custom_domain = true },
-# ]
+# Custom domains, wired up in the Cloudflare dashboard.
+routes = [
+  { pattern = "revision.city", custom_domain = true },
+  { pattern = "www.revision.city", custom_domain = true },
+]
 
 [observability]
 enabled = true

--- a/apps/startchi.com/wrangler.toml
+++ b/apps/startchi.com/wrangler.toml
@@ -4,12 +4,11 @@ main = "@tanstack/react-start/server-entry"
 compatibility_date = "2026-06-01"
 compatibility_flags = ["nodejs_compat"]
 
-# startchi.com is not wired to the worker yet, so it serves from its
-# workers.dev URL. Once the zone is connected, add:
-# routes = [
-#   { pattern = "startchi.com", custom_domain = true },
-#   { pattern = "www.startchi.com", custom_domain = true },
-# ]
+# Custom domains, wired up in the Cloudflare dashboard.
+routes = [
+  { pattern = "startchi.com", custom_domain = true },
+  { pattern = "www.startchi.com", custom_domain = true },
+]
 
 [observability]
 enabled = true

--- a/docs/projects/new-domain-sites/2026-06-14-progress.md
+++ b/docs/projects/new-domain-sites/2026-06-14-progress.md
@@ -40,7 +40,7 @@
 - David wired the custom domains in the Cloudflare dashboard; enabled the
   `custom_domain` routes in each app's `wrangler.toml`:
   - onvibes.org — `onvibes.org`, `www.onvibes.org`
-  - pkg.dog — `pkg.dog`, `pkgdog.com`, `www.pkgdog.com`
+  - pkg.dog — `pkg.dog`, `www.pkg.dog`, `pkgdog.com`, `www.pkgdog.com`
   - startchi.com — `startchi.com`, `www.startchi.com`
   - monicandavid.com — `monicandavid.com`, `www.monicandavid.com`
   - revision.city — `revision.city`, `www.revision.city`
@@ -51,6 +51,9 @@
   active but the worker attachment couldn't be confirmed over HTTP.
   revision.city didn't resolve from CI yet (DNS still propagating). David
   confirmed both should be enabled.
+- PR #240 review: David noted `www.pkg.dog` was missing from the pkg.dog routes.
+  Added it (grouped with the `pkg.dog` apex); probed `https://www.pkg.dog` →
+  HTTP 200, `<title>pkg.dog</title>`, so it's already serving the worker.
 
 ## Next
 

--- a/docs/projects/new-domain-sites/2026-06-14-progress.md
+++ b/docs/projects/new-domain-sites/2026-06-14-progress.md
@@ -30,4 +30,30 @@
 ## Next
 
 - Confirm the first deploy of each site is green after this lands on `main`.
-- Custom-domain wiring per site when the Cloudflare zones are connected.
+
+---
+
+# 2026-06-14 (later) — custom domains enabled
+
+## Done
+
+- David wired the custom domains in the Cloudflare dashboard; enabled the
+  `custom_domain` routes in each app's `wrangler.toml`:
+  - onvibes.org — `onvibes.org`, `www.onvibes.org`
+  - pkg.dog — `pkg.dog`, `pkgdog.com`, `www.pkgdog.com`
+  - startchi.com — `startchi.com`, `www.startchi.com`
+  - monicandavid.com — `monicandavid.com`, `www.monicandavid.com`
+  - revision.city — `revision.city`, `www.revision.city`
+- Verified before editing (no CF API tool for custom domains, so probed over
+  HTTP): onvibes.org, pkg.dog (+ pkgdog.com), and startchi.com already serve
+  their worker on the custom domain (HTTP 200, correct `<title>`).
+  monicandavid.com returns a Cloudflare "Just a moment…" challenge — zone is
+  active but the worker attachment couldn't be confirmed over HTTP.
+  revision.city didn't resolve from CI yet (DNS still propagating). David
+  confirmed both should be enabled.
+
+## Next
+
+- After merge, confirm each app's redeploy attaches the custom domains cleanly —
+  watch for wrangler "custom domain already exists / zone not found" errors,
+  especially on monicandavid.com and revision.city.

--- a/docs/projects/new-domain-sites/plan.md
+++ b/docs/projects/new-domain-sites/plan.md
@@ -29,9 +29,10 @@ alternative would be bare `tsc`. So: Astro → `astro check`, SvelteKit →
 apps → tsgo (no framework-specific checker; the alternative there is plain tsc).
 
 Every app now has a `cd-deploy-*` workflow that ships to its workers.dev URL on
-push to `main` (path-filtered to the app dir + its own workflow file). Custom-domain
-routes are not wired yet — the `routes` blocks in each `wrangler.toml` stay commented
-until the zones are connected.
+push to `main` (path-filtered to the app dir + its own workflow file). Custom domains
+are wired in the Cloudflare dashboard and enabled as `custom_domain` routes in each
+`wrangler.toml` (apex + www; pkg.dog also serves pkgdog.com) — wrangler reconciles
+them on the next deploy.
 
 ## Related
 


### PR DESCRIPTION
David wired the custom domains in the Cloudflare dashboard. This enables the previously-commented `custom_domain` routes in each app's `wrangler.toml` so wrangler reconciles them on the next deploy.

## Domains enabled

| App | Domains |
| --- | --- |
| onvibes.org | `onvibes.org`, `www.onvibes.org` |
| pkg.dog | `pkg.dog`, `www.pkg.dog`, `pkgdog.com`, `www.pkgdog.com` |
| startchi.com | `startchi.com`, `www.startchi.com` |
| monicandavid.com | `monicandavid.com`, `www.monicandavid.com` |
| revision.city | `revision.city`, `www.revision.city` |

## Verification

There's no Cloudflare API tool for custom domains, so each was probed over HTTP before editing:

- ✅ **onvibes.org**, **pkg.dog** (+ `www.pkg.dog`, `pkgdog.com`), **startchi.com** — already serving the worker on the custom domain (HTTP 200, correct `<title>`).
- ⚠️ **monicandavid.com** — returns a Cloudflare "Just a moment…" challenge; zone is active but the worker attachment couldn't be confirmed over HTTP. Enabled at David's direction.
- ⚠️ **revision.city** — didn't resolve from CI yet (DNS still propagating). Enabled at David's direction.

`www.pkg.dog` was added after David flagged it in review; it also probes HTTP 200.

## After merge

Confirm each app's redeploy attaches the custom domains cleanly — watch for wrangler "custom domain already exists / zone not found" errors, especially on **monicandavid.com** and **revision.city**.

Progress notes: `docs/projects/new-domain-sites/2026-06-14-progress.md`

https://claude.ai/code/session_01TB4X8fsDPyMUsyG88Lqkka