### PR TITLE
Testing harness: per-app smoke gates, unit tests, and coverage ratchets

### DIFF
--- a/.claude/hooks/session-start.ts
+++ b/.claude/hooks/session-start.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+import {$} from 'bun'
+import {appendFileSync, existsSync, readdirSync} from 'node:fs'
+import {homedir} from 'node:os'
+import {join, resolve} from 'node:path'
+
+// SessionStart hook for Claude Code on the web.
+//
+// A fresh web container ships with neither the mise toolchain nor any app's
+// node_modules, so it cannot run a single mise task or boot an app. This hook
+// bootstraps both: it installs the mise-pinned toolchain (node, pnpm, bun, and
+// the linters) and every app's dependencies, so checks (typecheck / lint /
+// format / test / build) and smoke boots work the same way they do in CI.
+//
+// No-op outside the remote web environment -- local machines manage their own
+// toolchain through mise's shell activation.
+if (process.env.CLAUDE_CODE_REMOTE !== 'true') process.exit(0)
+
+const home = homedir()
+const repo = process.env.CLAUDE_PROJECT_DIR ?? resolve(import.meta.dir, '../..')
+const localBin = join(home, '.local', 'bin')
+const shims = join(home, '.local', 'share', 'mise', 'shims')
+
+// 1. Install mise itself if the container doesn't already have it.
+if (!existsSync(join(localBin, 'mise')) && !Bun.which('mise')) {
+  await $`curl -fsSL https://mise.run | sh`
+}
+
+// Make mise and its shimmed tools resolvable for the rest of this process, and
+// trust the repo config (mise refuses untrusted configs non-interactively).
+process.env.PATH = `${localBin}:${shims}:${process.env.PATH}`
+process.env.MISE_TRUSTED_CONFIG_PATHS = repo
+
+// 2. Install the toolchain pinned in .config/mise.toml. The committed
+//    mise.lock keeps versions deterministic and avoids GitHub release-API
+//    lookups, which rate-limit on unauthenticated containers.
+await $`mise trust --yes ${join(repo, '.config', 'mise.toml')}`.nothrow().quiet()
+await $`mise install`.cwd(repo)
+
+// 3. Persist the toolchain on PATH (plus trust) for every later command in the
+//    session, via the env file the harness sources between tool calls.
+const envFile = process.env.CLAUDE_ENV_FILE
+if (envFile) {
+  appendFileSync(
+    envFile,
+    `export PATH="${localBin}:${shims}:$PATH"\n` +
+      `export MISE_TRUSTED_CONFIG_PATHS="${repo}"\n`,
+  )
+}
+
+// 4. Install dependencies for every app. Lockfiles are independent (this repo
+//    has no pnpm workspace), so each app installs on its own. CI=true makes
+//    pnpm non-interactive and CI-faithful: it installs frozen from the lockfile
+//    (so `latest` dev deps don't drift between runs) and auto-confirms a
+//    node_modules purge that would otherwise abort without a TTY. Keep going if
+//    one app fails -- a single broken install shouldn't block the session.
+const appsDir = join(repo, 'apps')
+const installEnv = {...process.env, CI: 'true'}
+for (const entry of readdirSync(appsDir, {withFileTypes: true})) {
+  if (!entry.isDirectory()) continue
+  const appDir = join(appsDir, entry.name)
+  if (!existsSync(join(appDir, 'package.json'))) continue
+  console.log(`==> pnpm install: apps/${entry.name}`)
+  let result = await $`pnpm install --prefer-offline`.cwd(appDir).env(installEnv).nothrow().quiet()
+  if (result.exitCode !== 0) {
+    // Retry unfrozen to ride out lockfile drift or a transient store blip.
+    result = await $`pnpm install --no-frozen-lockfile`.cwd(appDir).env(installEnv).nothrow().quiet()
+  }
+  if (result.exitCode !== 0) {
+    console.error(`WARN: pnpm install failed in apps/${entry.name}`)
+    console.error(result.stdout.toString())
+    console.error(result.stderr.toString())
+  }
+}
+
+console.log('session-start: toolchain + app dependencies ready')

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/session-start.ts"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -25,3 +25,16 @@ dir = "{{config_root}}"
 description = "Apply formatting fixes to repo-root config files"
 run = "biome check --write biome.jsonc .oxlintrc.json .prettierrc.json .config/cspell.json .github/renovate.json .vscode/settings.json .vscode/extensions.json"
 dir = "{{config_root}}"
+
+# Monorepo aggregators: fan a task out to every app. Per-app CI still runs each
+# app's tasks on path-filtered triggers; these are the local "verify everything"
+# commands. They run each app with CI=true to dodge pnpm's no-TTY deps-purge abort.
+[tasks.test]
+description = "Run every app's unit tests"
+run = "bun bin/run-app-tasks.ts test"
+dir = "{{config_root}}"
+
+[tasks.check]
+description = "Run every app's full check (typecheck, lint, format, test, build)"
+run = "bun bin/run-app-tasks.ts check"
+dir = "{{config_root}}"

--- a/.github/workflows/ci-calendar-visualizer.yml
+++ b/.github/workflows/ci-calendar-visualizer.yml
@@ -148,3 +148,27 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/.github/workflows/ci-davidjfelix-com.yml
+++ b/.github/workflows/ci-davidjfelix-com.yml
@@ -148,3 +148,27 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/.github/workflows/ci-f311x.yml
+++ b/.github/workflows/ci-f311x.yml
@@ -150,3 +150,27 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/.github/workflows/ci-forzamonica-com.yml
+++ b/.github/workflows/ci-forzamonica-com.yml
@@ -150,3 +150,27 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/.github/workflows/ci-ravrun.yml
+++ b/.github/workflows/ci-ravrun.yml
@@ -148,3 +148,27 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,11 @@ Build-time checks (typecheck, lint, unit, build) can't catch an app that builds 
 - **CI**: a `smoke` job per deployed app, mirroring the `vitest` job.
 - **e2e** (Playwright, `*.e2e.test.ts`) is the heavier browser-based layer for hydration / interaction / visual regression; optional per app, and a superset of smoke (see `apps/djf.io`).
 
+### Coverage & the monorepo aggregator
+
+- Apps with real unit-testable logic gate it with **vitest v8 coverage scoped to the logic** -- not UI / route / worker glue, which smoke + e2e cover. Set `coverage.include` to the tested modules (e.g. `src/lib/**`) and `coverage.thresholds` as a ratchet at / just under current, and run the unit task with `--coverage` so CI enforces it. f311x and djf.io are wired (100% on their logic); calendar-visualizer and forzamonica.com follow the same recipe. (Under Astro's `getViteConfig` the per-file `text` table renders empty -- cosmetic; `text-summary` and threshold enforcement work.)
+- **`mise run test` / `mise run check` at the repo root** fan the task out to every app (`bin/run-app-tasks.ts`), for a one-command "verify the whole monorepo" -- complementing the per-app, path-filtered CI. They run each app with `CI=true` so pnpm's no-TTY deps-purge check can't abort.
+
 ## Apps
 
 ### djf.io (Personal Site)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,16 @@ When in doubt, prefer kebab-case. If a third-party tool requires a different cas
 - **Avoid `beforeEach`/`beforeAll`/`afterEach`/`afterAll`** unless a framework requires it. Prefer top-level setup (top-level `await` for async), inline setup inside each test, or a small named helper called from each test. Hooks hide control flow and make tests harder to read.
 - **For tests inside `src/pages/` (Astro routing constraint)**: prefix with `_` (e.g. `_index.e2e.test.ts`). Astro treats every `.ts` in `src/pages/` as an endpoint; the underscore is its built-in escape hatch. Outside `src/pages/`, no prefix.
 
+### Runtime checks: smoke and e2e
+
+Build-time checks (typecheck, lint, unit, build) can't catch an app that builds green but is broken at runtime (f311x shipped that way on 2026-06-11). Every **deployed** app gets a canonical runtime gate — a `smoke` mise task, or a Playwright e2e suite that subsumes it (`apps/djf.io`):
+
+- **Contract**: `mise run smoke` (declares `depends = ["build"]`) boots the app's _production build_ locally and asserts the critical path serves — each key route returns 200 as a complete document whose hashed client assets also serve; an app with a backend also exercises it (f311x POSTs the chat endpoint and requires the echo stream). Deterministic and secret-free, so it runs on every PR.
+- **Boot per stack** (reference scripts live in each app's `bin/smoke-local.ts`, bun): static Astro → `astro preview`; Vite SPA → `vite preview`; Cloudflare Worker / SSR → `wrangler dev` on the built worker (workerd), because `*-preview` only serves static assets. Spawn the preview **binary directly** (`node_modules/.bin/...`), not via `pnpm run` — killing the pnpm wrapper doesn't cascade to the server, so it outlives teardown and holds the port.
+- **Knobs**: `SMOKE_*` env vars (URLs / routes / port) keep the same checks pointable at a local boot now and a per-PR preview deploy later.
+- **CI**: a `smoke` job per deployed app, mirroring the `vitest` job.
+- **e2e** (Playwright, `*.e2e.test.ts`) is the heavier browser-based layer for hydration / interaction / visual regression; optional per app, and a superset of smoke (see `apps/djf.io`).
+
 ## Apps
 
 ### djf.io (Personal Site)

--- a/apps/calendar-visualizer/bin/smoke-local.ts
+++ b/apps/calendar-visualizer/bin/smoke-local.ts
@@ -1,0 +1,84 @@
+/// <reference types="bun" />
+// Pre-merge smoke gate: boots the production preview server and checks the
+// critical path serves a working bundle -- each route returns 200, the response
+// is a complete HTML document, and any hashed client asset it references itself
+// serves. Catches the "deployed but broken" class (route 404/500, missing
+// assets) before merge. Deterministic and secret-free.
+//
+// Assumes `astro build` has run (the `smoke` mise task depends on `build`). The
+// gate is parameterized (SMOKE_ROUTES / SMOKE_PORT) so the same checks can later
+// target a per-PR preview deploy.
+
+import {existsSync} from 'node:fs'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4321)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const ROUTES = (process.env.SMOKE_ROUTES ?? '/').split(',')
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync('dist')) {
+  console.error('::error::dist is missing -- run `mise run build` first')
+  process.exit(1)
+}
+
+// Spawn the preview binary directly (not through `pnpm run`): killing the pnpm
+// wrapper does not cascade to the server, so it would outlive teardown and hold
+// the port. Detached stdio keeps the server from holding this process's pipes
+// open, which would otherwise stall a `... | tail` pipeline after we exit.
+const server = Bun.spawn(
+  ['node_modules/.bin/astro', 'preview', '--host', '127.0.0.1', '--port', String(PORT)],
+  {env: {...process.env, CI: 'true'}, stdout: 'ignore', stderr: 'ignore'},
+)
+
+async function check(route: string): Promise<string | null> {
+  const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `${route} -> HTTP ${page.status}`
+  const html = await page.text()
+  if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
+  if (asset) {
+    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
+  }
+  return null
+}
+
+async function waitForReady(): Promise<boolean> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) return true
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+  return false
+}
+
+let exitCode = 0
+try {
+  if (!(await waitForReady())) {
+    console.error(
+      `::error::preview did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    for (const route of ROUTES) {
+      const problem = await check(route)
+      if (problem === null) {
+        console.log(`OK: ${route} serves a working bundle`)
+      } else {
+        console.error(`::error::smoke test failed — ${problem}`)
+        exitCode = 1
+      }
+    }
+  }
+} finally {
+  server.kill()
+  await Promise.race([server.exited, Bun.sleep(3_000)])
+  server.kill('SIGKILL')
+}
+
+process.exit(exitCode)

--- a/apps/calendar-visualizer/mise.toml
+++ b/apps/calendar-visualizer/mise.toml
@@ -28,6 +28,11 @@ run = "pnpm run test"
 description = "Build with Astro"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (astro preview)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/calendar-visualizer/package.json
+++ b/apps/calendar-visualizer/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "biome check --write .",
     "format": "biome format . && prettier --check --no-error-on-unmatched-pattern \"**/*.md\" \"**/*.mdx\"",
     "format:fix": "biome format --write . && prettier --write --no-error-on-unmatched-pattern \"**/*.md\" \"**/*.mdx\"",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "test:watch": "vitest",
     "spell": "cspell --config ../../.config/cspell.json \"**\""
   },
@@ -32,6 +32,7 @@
     "@cspell/dict-typescript": "3.2.3",
     "@pandacss/dev": "1.11.3",
     "@types/bun": "1.3.14",
+    "@vitest/coverage-v8": "4.1.8",
     "cspell": "10.0.1",
     "vitest": "4.1.8",
     "wrangler": "4.100.0"

--- a/apps/calendar-visualizer/package.json
+++ b/apps/calendar-visualizer/package.json
@@ -31,6 +31,7 @@
     "@astrojs/check": "0.9.9",
     "@cspell/dict-typescript": "3.2.3",
     "@pandacss/dev": "1.11.3",
+    "@types/bun": "1.3.14",
     "cspell": "10.0.1",
     "vitest": "4.1.8",
     "wrangler": "4.100.0"

--- a/apps/calendar-visualizer/pnpm-lock.yaml
+++ b/apps/calendar-visualizer/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@pandacss/dev':
         specifier: 1.11.3
         version: 1.11.3(typescript@6.0.2)
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
       cspell:
         specifier: 10.0.1
         version: 10.0.1
@@ -1489,6 +1492,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1722,6 +1728,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -5027,6 +5036,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -5394,6 +5407,10 @@ snapshots:
       electron-to-chromium: 1.5.372
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 17.0.45
 
   bytes@3.1.2: {}
 

--- a/apps/calendar-visualizer/pnpm-lock.yaml
+++ b/apps/calendar-visualizer/pnpm-lock.yaml
@@ -45,12 +45,15 @@ importers:
       '@types/bun':
         specifier: 1.3.14
         version: 1.3.14
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       cspell:
         specifier: 10.0.1
         version: 10.0.1
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(vite@7.3.5(lightningcss@1.31.1)(yaml@2.9.0))
+        version: 4.1.8(@vitest/coverage-v8@4.1.8)(vite@7.3.5(lightningcss@1.31.1)(yaml@2.9.0))
       wrangler:
         specifier: 4.100.0
         version: 4.100.0
@@ -189,6 +192,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
@@ -1542,6 +1549,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -1671,6 +1687,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -2283,6 +2302,10 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2324,6 +2347,9 @@ packages:
   hono@4.12.25:
     resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -2416,6 +2442,18 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jalaali-js@1.2.8:
     resolution: {integrity: sha512-Jl/EwY84JwjW2wsWqeU4pNd22VNQ7EkjI36bDuLw31wH98WQW4fPjD0+mG7cdCK+Y8D6s9R3zLiQ3LaKu6bD8A==}
 
@@ -2424,6 +2462,9 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2562,6 +2603,10 @@ packages:
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -3197,6 +3242,10 @@ packages:
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
@@ -3952,6 +4001,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@capsizecss/unpack@4.0.1':
     dependencies:
@@ -5093,6 +5144,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@vitest/coverage-v8@4.1.8)(vite@7.3.5(lightningcss@1.31.1)(yaml@2.9.0))
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -5260,6 +5325,12 @@ snapshots:
   array-timsort@1.0.3: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astral-regex@2.0.0: {}
 
@@ -6050,6 +6121,8 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.4:
@@ -6145,6 +6218,8 @@ snapshots:
 
   hono@4.12.25: {}
 
+  html-escaper@2.0.2: {}
+
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
@@ -6207,11 +6282,26 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jalaali-js@1.2.8: {}
 
   javascript-stringify@2.1.0: {}
 
   jose@6.2.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -6313,6 +6403,10 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.4
 
   markdown-table@3.0.4: {}
 
@@ -7198,6 +7292,10 @@ snapshots:
 
   supports-color@10.2.2: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   svgo@4.0.1:
     dependencies:
       commander: 11.1.0
@@ -7405,7 +7503,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(lightningcss@1.31.1)(yaml@2.9.0)
 
-  vitest@4.1.8(vite@7.3.5(lightningcss@1.31.1)(yaml@2.9.0)):
+  vitest@4.1.8(@vitest/coverage-v8@4.1.8)(vite@7.3.5(lightningcss@1.31.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@7.3.5(lightningcss@1.31.1)(yaml@2.9.0))
@@ -7427,6 +7525,8 @@ snapshots:
       tinyrainbow: 3.1.0
       vite: 7.3.5(lightningcss@1.31.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
 

--- a/apps/calendar-visualizer/vitest.config.ts
+++ b/apps/calendar-visualizer/vitest.config.ts
@@ -5,5 +5,13 @@ export default getViteConfig({
   test: {
     include: ['src/**/*.test.{ts,tsx}'],
     exclude: ['**/*.e2e.test.ts', '**/node_modules/**'],
+    // Coverage gate for the app's pure logic (the calendar state builder). The
+    // React rendering in calendar.tsx is exercised by smoke, not unit coverage.
+    coverage: {
+      provider: 'v8',
+      include: ['src/components/calendar-state.ts'],
+      reporter: ['text', 'text-summary'],
+      thresholds: {statements: 100, branches: 90, functions: 100, lines: 100},
+    },
   },
 })

--- a/apps/davidjfelix.com/bin/smoke-local.ts
+++ b/apps/davidjfelix.com/bin/smoke-local.ts
@@ -1,0 +1,84 @@
+/// <reference types="bun" />
+// Pre-merge smoke gate: boots the production preview server and checks the
+// critical path serves a working bundle -- each route returns 200, the response
+// is a complete HTML document, and any hashed client asset it references itself
+// serves. Catches the "deployed but broken" class (route 404/500, missing
+// assets) before merge. Deterministic and secret-free.
+//
+// Assumes `astro build` has run (the `smoke` mise task depends on `build`). The
+// gate is parameterized (SMOKE_ROUTES / SMOKE_PORT) so the same checks can later
+// target a per-PR preview deploy.
+
+import {existsSync} from 'node:fs'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4321)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const ROUTES = (process.env.SMOKE_ROUTES ?? '/').split(',')
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync('dist')) {
+  console.error('::error::dist is missing -- run `mise run build` first')
+  process.exit(1)
+}
+
+// Spawn the preview binary directly (not through `pnpm run`): killing the pnpm
+// wrapper does not cascade to the server, so it would outlive teardown and hold
+// the port. Detached stdio keeps the server from holding this process's pipes
+// open, which would otherwise stall a `... | tail` pipeline after we exit.
+const server = Bun.spawn(
+  ['node_modules/.bin/astro', 'preview', '--host', '127.0.0.1', '--port', String(PORT)],
+  {env: {...process.env, CI: 'true'}, stdout: 'ignore', stderr: 'ignore'},
+)
+
+async function check(route: string): Promise<string | null> {
+  const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `${route} -> HTTP ${page.status}`
+  const html = await page.text()
+  if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
+  if (asset) {
+    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
+  }
+  return null
+}
+
+async function waitForReady(): Promise<boolean> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) return true
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+  return false
+}
+
+let exitCode = 0
+try {
+  if (!(await waitForReady())) {
+    console.error(
+      `::error::preview did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    for (const route of ROUTES) {
+      const problem = await check(route)
+      if (problem === null) {
+        console.log(`OK: ${route} serves a working bundle`)
+      } else {
+        console.error(`::error::smoke test failed — ${problem}`)
+        exitCode = 1
+      }
+    }
+  }
+} finally {
+  server.kill()
+  await Promise.race([server.exited, Bun.sleep(3_000)])
+  server.kill('SIGKILL')
+}
+
+process.exit(exitCode)

--- a/apps/davidjfelix.com/mise.toml
+++ b/apps/davidjfelix.com/mise.toml
@@ -28,6 +28,11 @@ run = "pnpm run test"
 description = "Build with Astro"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (astro preview)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/davidjfelix.com/package.json
+++ b/apps/davidjfelix.com/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@astrojs/check": "0.9.9",
     "@cspell/dict-typescript": "3.2.3",
+    "@types/bun": "1.3.14",
     "@typescript/native-preview": "latest",
     "cspell": "10.0.1",
     "vitest": "4.1.8",

--- a/apps/davidjfelix.com/pnpm-lock.yaml
+++ b/apps/davidjfelix.com/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       astro:
-        specifier: ^6.4.6
-        version: 6.4.6(rollup@4.62.0)(yaml@2.9.0)
+        specifier: ^6.3.7
+        version: 6.4.6(@types/node@25.9.3)(rollup@4.62.0)(yaml@2.9.0)
     devDependencies:
       '@astrojs/check':
         specifier: 0.9.9
@@ -18,15 +18,18 @@ importers:
       '@cspell/dict-typescript':
         specifier: 3.2.3
         version: 3.2.3
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
       '@typescript/native-preview':
         specifier: latest
-        version: 7.0.0-dev.20260614.1
+        version: 7.0.0-dev.20260613.1
       cspell:
         specifier: 10.0.1
         version: 10.0.1
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(vite@7.3.5(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
       wrangler:
         specifier: 4.100.0
         version: 4.100.0
@@ -1083,6 +1086,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1107,53 +1113,56 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-2JHbdJ00FKTKDR1+NL4zhQBDlFZfZHEXaAarV6kbEjV0P47qKnSrAzzKHuponG0B9FqkPEMHOgu7WGJTBW2rHw==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260613.1':
+    resolution: {integrity: sha512-znTFp/M0SpN91/FM3FrsTycdTZr+bLszmHObm2LaR5sgo1c2wiK4qYsMnrhLeP0vSMD2LuiNg5J21501h7Aj6g==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-/8enyEb1tDsVvUp4rDeA5DernrvWgD6cQ4rY6O6PH6BQK8fqwY+CcHEHmw2xgwfqoswHNYjznLvmQmHBOjHqLw==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260613.1':
+    resolution: {integrity: sha512-7zXTq3SVw6XCLdm06VRIhMzayG032Ky14xCZ3isnlcm1KD/p4Ev4XL9TN9fZmIV0bVPGMQr4qGS7a2+te8x7lg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-jqhqAXqyEUxJpno/wRfWGa72R3VTt7p2LRTOFJ0C1bx5dEKrVosQSOdr2m9+2VhjXFXNvorXsGZPIWqxLOo28Q==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260613.1':
+    resolution: {integrity: sha512-yYiDEMT4ok7Wd1VtbyB+0YqBdTkU/yzE36edZCbfA/Ljt6L1xZMEn0a7XGlmRtRfwPGHfjtFRFsxrA2nc7jHnw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-zYrUKq5oC6fUoHpOmT3B65hFMhbdIlLp7T9RW1/6a+wSYoq9xTRAeFufQ2XZ9cpTJ1tfIvlUmtgJJ5CGE/cOrg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260613.1':
+    resolution: {integrity: sha512-xpA7nXiRE3fwvTUK2ibhkPr7hn6D4i3pB9WjlcX7CSPB2pYGMdHAsL55EAFlR3eNKyNM/geoLfqq4L4PIeOWsQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-K2c/DN7Q3a6Z+KIl7bq45xByuuGjacqWO/UPCa/iTBA/m6GDzoMJ/Q/DBLtLRHyROBRiy5kjgEZfyLy3Tp8ygw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260613.1':
+    resolution: {integrity: sha512-mZO9hIwXek9VO+N+gs6IKDOf0fPnrQg/SvaOsCDcDwsk7a60yPbacyY7IiXFnxhNgZDLsYqs8j9ojDGl6+Tp5g==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-C+C25Grr4sCbQIYPT5WfKYIL613ZIN9aGcUwDGMSTmIQ3azIR5MtdkSF4l4vsOC4lF8HwFV83MDa28JuQYhQFg==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260613.1':
+    resolution: {integrity: sha512-JtMTHRt7auXTCvvOtcn7aX1gdCPByQl4c5vc8e1d+8PcqtMqeSpH1j0Vp06F9vugTA+YMIzFsJQA91sUK1oHeg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-nJBR61NGiCMBJOpdzJ4ZgA/HEd+fqIb99ur39UljSH9xvFKFlRwDosyAQFD8UEwrZsUbXN0VPLJY5MDknug3GA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260613.1':
+    resolution: {integrity: sha512-aCZaFWHDt5n8B++F2FrTK2pF7muAFfkvi8qkUnC0N0SNBGdVnqlO28IbdjScIfI2JFOvgZtUoYWeATGWdrLXBA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-4N1ZBHJUcsjKJQnUCxKUemV3jnm0PKZIZ4xh7dXN/3/AfmckE8Z1llyqOFfDwGOf8oQpdgkwQ6JUm7pqI3bGPg==}
+  '@typescript/native-preview@7.0.0-dev.20260613.1':
+    resolution: {integrity: sha512-RJ3YrYNoshFGVY862CwZ/WcICvMW0u9XtezI8AAU81I71Cr3/IJoHPUGsGKUr2gVcPfKRQiaI8YTndFzUGvSug==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -1276,6 +1285,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2166,6 +2178,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
@@ -3366,6 +3381,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3393,38 +3412,42 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@25.9.3':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/unist@3.0.3': {}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260613.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260613.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260613.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260613.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260613.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260613.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260613.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
+  '@typescript/native-preview@7.0.0-dev.20260613.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260614.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260613.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260613.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260613.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260613.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260613.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260613.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260613.1
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -3437,13 +3460,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.5(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -3553,7 +3576,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  astro@6.4.6(rollup@4.62.0)(yaml@2.9.0):
+  astro@6.4.6(@types/node@25.9.3)(rollup@4.62.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0
@@ -3605,8 +3628,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.5(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.5(yaml@2.9.0))
+      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -3653,6 +3676,10 @@ snapshots:
   blake3-wasm@2.1.5: {}
 
   boolbase@1.0.0: {}
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.9.3
 
   ccount@2.0.1: {}
 
@@ -4874,6 +4901,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
+  undici-types@7.24.6: {}
+
   undici@7.24.8: {}
 
   unenv@2.0.0-rc.24:
@@ -4964,7 +4993,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.5(yaml@2.9.0):
+  vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4973,17 +5002,18 @@ snapshots:
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 25.9.3
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.5(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.5(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
 
-  vitest@4.1.8(vite@7.3.5(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.5(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@25.9.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -5000,8 +5030,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.3
     transitivePeerDependencies:
       - msw
 

--- a/apps/davidjfelix.com/pnpm-lock.yaml
+++ b/apps/davidjfelix.com/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       astro:
-        specifier: ^6.3.7
+        specifier: ^6.4.6
         version: 6.4.6(@types/node@25.9.3)(rollup@4.62.0)(yaml@2.9.0)
     devDependencies:
       '@astrojs/check':
@@ -23,7 +23,7 @@ importers:
         version: 1.3.14
       '@typescript/native-preview':
         specifier: latest
-        version: 7.0.0-dev.20260613.1
+        version: 7.0.0-dev.20260615.1
       cspell:
         specifier: 10.0.1
         version: 10.0.1
@@ -1119,50 +1119,50 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260613.1':
-    resolution: {integrity: sha512-znTFp/M0SpN91/FM3FrsTycdTZr+bLszmHObm2LaR5sgo1c2wiK4qYsMnrhLeP0vSMD2LuiNg5J21501h7Aj6g==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-EHrtoVGEEhIhsnGe+b8w0FoM9JfIw5SkoPwO8ifaU0PrYm2UbyPbj2I2hOTxtk458t0irvGz2+8cshylBRbKng==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260613.1':
-    resolution: {integrity: sha512-7zXTq3SVw6XCLdm06VRIhMzayG032Ky14xCZ3isnlcm1KD/p4Ev4XL9TN9fZmIV0bVPGMQr4qGS7a2+te8x7lg==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-BcDA56hkk6mrUpysaOVvrdACoX5d2SF1JTwHMoNjT1KysBicExS2wlH0eN0L01iDeqtB73XHl7A4zrKFmKzrBg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260613.1':
-    resolution: {integrity: sha512-yYiDEMT4ok7Wd1VtbyB+0YqBdTkU/yzE36edZCbfA/Ljt6L1xZMEn0a7XGlmRtRfwPGHfjtFRFsxrA2nc7jHnw==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-TDAlBpyYCF7Z+ELTH+1tabDE6W3shl+H+Z+nmzaQio1I8pFvbwt2iLlE0Rc9CpRdIeaqr0ppMEgXHoeV3fZFWA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260613.1':
-    resolution: {integrity: sha512-xpA7nXiRE3fwvTUK2ibhkPr7hn6D4i3pB9WjlcX7CSPB2pYGMdHAsL55EAFlR3eNKyNM/geoLfqq4L4PIeOWsQ==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-YRXRS/7ZqrDKXBJhFQcZiOdnHRuRbWoL/QkggpoGfhIuSAh4HvTU0WEUnPM+jRnH2kUMfsSgd8EAnPvmuP7/VA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260613.1':
-    resolution: {integrity: sha512-mZO9hIwXek9VO+N+gs6IKDOf0fPnrQg/SvaOsCDcDwsk7a60yPbacyY7IiXFnxhNgZDLsYqs8j9ojDGl6+Tp5g==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-/QDmRWt6abB7fw3yMchjlyDXej/7Dr8mYG4wvGGf6c1hc5Il5UpDQWNHejatdeKvAu+sszz8JhTuL8et47fTTg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260613.1':
-    resolution: {integrity: sha512-JtMTHRt7auXTCvvOtcn7aX1gdCPByQl4c5vc8e1d+8PcqtMqeSpH1j0Vp06F9vugTA+YMIzFsJQA91sUK1oHeg==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-WTJOLoe2rxT0W1i8ndWk2MKrakxRFNki537JZxvKAmSTbyOZznHlW3O3dbryUtTBYA716DDqS3ci24kuIfvBdg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260613.1':
-    resolution: {integrity: sha512-aCZaFWHDt5n8B++F2FrTK2pF7muAFfkvi8qkUnC0N0SNBGdVnqlO28IbdjScIfI2JFOvgZtUoYWeATGWdrLXBA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-4cSCpXG7um18nwmLdU/SjoTv3OcO38/ufTiy1oWVccgGHLJqppiOP9/o+ElKIWhvrp78IaGy8+h3YqEjQ4/pcQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260613.1':
-    resolution: {integrity: sha512-RJ3YrYNoshFGVY862CwZ/WcICvMW0u9XtezI8AAU81I71Cr3/IJoHPUGsGKUr2gVcPfKRQiaI8YTndFzUGvSug==}
+  '@typescript/native-preview@7.0.0-dev.20260615.1':
+    resolution: {integrity: sha512-JJ8X1l7H1GrnseK1k30qfQqB8Pz6jw3IALZVIj5oXQeRbUCe0Wx3ljkJEmOpunogdhEfA8IlOggskbUjVsXKBQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -3418,36 +3418,36 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260613.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260613.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260613.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260613.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260613.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260613.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260613.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260615.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260613.1':
+  '@typescript/native-preview@7.0.0-dev.20260615.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260613.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260613.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260613.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260613.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260613.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260613.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260613.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260615.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260615.1
 
   '@ungap/structured-clone@1.3.1': {}
 

--- a/apps/djf.io/package.json
+++ b/apps/djf.io/package.json
@@ -16,7 +16,7 @@
     "format:fix": "biome format --write . && prettier --write --no-error-on-unmatched-pattern \"**/*.md\" \"**/*.mdx\"",
     "spell": "cspell --config ../../.config/cspell.json \"**\"",
     "test": "pnpm test:unit && pnpm test:e2e",
-    "test:unit": "vitest run",
+    "test:unit": "vitest run --coverage",
     "test:unit:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
@@ -42,6 +42,7 @@
     "@cspell/dict-typescript": "3.2.3",
     "@pandacss/dev": "1.11.3",
     "@playwright/test": "1.60.0",
+    "@vitest/coverage-v8": "4.1.8",
     "cspell": "10.0.1",
     "pagefind": "1.5.2",
     "vitest": "4.1.8",

--- a/apps/djf.io/pnpm-lock.yaml
+++ b/apps/djf.io/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       cspell:
         specifier: 10.0.1
         version: 10.0.1
@@ -71,7 +74,7 @@ importers:
         version: 1.5.2
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@types/node@24.13.2)(vite@7.3.5(@types/node@24.13.2)(lightningcss@1.31.1)(yaml@2.9.0))
+        version: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@24.13.2)(lightningcss@1.31.1)(yaml@2.9.0))
       wrangler:
         specifier: 4.100.0
         version: 4.100.0
@@ -226,6 +229,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
@@ -1850,6 +1857,15 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -1995,6 +2011,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -2645,6 +2664,10 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2696,6 +2719,9 @@ packages:
   hono@4.12.25:
     resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -2803,11 +2829,26 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2946,6 +2987,10 @@ packages:
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -3687,6 +3732,10 @@ packages:
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
@@ -4490,6 +4539,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@capsizecss/unpack@4.0.1':
     dependencies:
@@ -5842,6 +5893,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@24.13.2)(lightningcss@1.31.1)(yaml@2.9.0))
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -6019,6 +6084,12 @@ snapshots:
   array-timsort@1.0.3: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astral-regex@2.0.0: {}
 
@@ -6856,6 +6927,8 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.4:
@@ -6994,6 +7067,8 @@ snapshots:
 
   hono@4.12.25: {}
 
+  html-escaper@2.0.2: {}
+
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
@@ -7069,9 +7144,24 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   javascript-stringify@2.1.0: {}
 
   jose@6.2.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -7176,6 +7266,10 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.4
 
   markdown-extensions@2.0.0: {}
 
@@ -8329,6 +8423,10 @@ snapshots:
 
   supports-color@10.2.2: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   svgo@4.0.1:
     dependencies:
       commander: 11.1.0
@@ -8548,7 +8646,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@24.13.2)(lightningcss@1.31.1)(yaml@2.9.0)
 
-  vitest@4.1.8(@types/node@24.13.2)(vite@7.3.5(@types/node@24.13.2)(lightningcss@1.31.1)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@24.13.2)(lightningcss@1.31.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.13.2)(lightningcss@1.31.1)(yaml@2.9.0))
@@ -8572,6 +8670,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.2
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
 

--- a/apps/djf.io/src/layouts/BlogPost.astro
+++ b/apps/djf.io/src/layouts/BlogPost.astro
@@ -2,6 +2,7 @@
 import {Image} from 'astro:assets'
 import type {CollectionEntry} from 'astro:content'
 import {css} from 'styled-system/css'
+import {formatBlogDate} from '../lib/blog'
 import BaseLayout from './BaseLayout.astro'
 
 interface Props {
@@ -11,11 +12,7 @@ interface Props {
 const {post} = Astro.props
 const {title, description, date, author, tags, readingTime, hero} = post.data
 
-const formattedDate = new Date(date).toLocaleDateString('en-US', {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-})
+const formattedDate = formatBlogDate(date)
 
 const ogImage = `/og/blog/${post.id}.png`
 const postUrl = Astro.site ? new URL(`/blog/${post.id}/`, Astro.site) : undefined

--- a/apps/djf.io/src/lib/blog.test.ts
+++ b/apps/djf.io/src/lib/blog.test.ts
@@ -1,0 +1,68 @@
+import {expect, test} from 'vitest'
+import {collectTags, formatBlogDate, postsForTag, sortPostsByDateDesc, tagCountsDesc} from './blog'
+
+const post = (date: string, tags?: Array<string>) => ({
+  data: {date: new Date(date), ...(tags === undefined ? {} : {tags})},
+})
+
+test('sortPostsByDateDesc orders posts newest first', () => {
+  const a = post('2025-01-01')
+  const b = post('2025-06-01')
+  const c = post('2024-12-31')
+  expect(sortPostsByDateDesc([a, b, c])).toEqual([b, a, c])
+})
+
+test('sortPostsByDateDesc does not mutate the input array', () => {
+  const input = [post('2025-01-01'), post('2025-02-01')]
+  const snapshot = [...input]
+  sortPostsByDateDesc(input)
+  expect(input).toEqual(snapshot)
+})
+
+test('sortPostsByDateDesc returns an empty array unchanged', () => {
+  expect(sortPostsByDateDesc([])).toEqual([])
+})
+
+test('collectTags returns each distinct tag once, in first-seen order', () => {
+  const posts = [post('2025-01-01', ['running', 'meta']), post('2025-02-01', ['meta', 'life'])]
+  expect(collectTags(posts)).toEqual(['running', 'meta', 'life'])
+})
+
+test('collectTags skips posts without tags', () => {
+  expect(collectTags([post('2025-01-01'), post('2025-02-01', ['running'])])).toEqual(['running'])
+})
+
+test('tagCountsDesc counts tag usage, most-used first', () => {
+  const posts = [
+    post('2025-01-01', ['running', 'meta']),
+    post('2025-02-01', ['meta']),
+    post('2025-03-01', ['meta', 'running']),
+  ]
+  expect(tagCountsDesc(posts)).toEqual([
+    ['meta', 3],
+    ['running', 2],
+  ])
+})
+
+test('tagCountsDesc is empty when no post has tags', () => {
+  expect(tagCountsDesc([post('2025-01-01'), post('2025-02-01')])).toEqual([])
+})
+
+test('postsForTag returns only matching posts, newest first', () => {
+  const a = post('2025-01-01', ['running'])
+  const b = post('2025-06-01', ['running', 'meta'])
+  const c = post('2025-03-01', ['life'])
+  expect(postsForTag([a, b, c], 'running')).toEqual([b, a])
+})
+
+test('postsForTag returns an empty array when no post carries the tag', () => {
+  expect(postsForTag([post('2025-01-01', ['running'])], 'absent')).toEqual([])
+})
+
+test('formatBlogDate renders a long-form en-US date', () => {
+  expect(formatBlogDate(new Date(2025, 11, 7))).toBe('December 7, 2025')
+})
+
+test('formatBlogDate renders single-digit days without padding', () => {
+  expect(formatBlogDate(new Date(2025, 4, 5))).toBe('May 5, 2025')
+})

--- a/apps/djf.io/src/lib/blog.ts
+++ b/apps/djf.io/src/lib/blog.ts
@@ -1,0 +1,45 @@
+// Pure helpers for the blog list and tag pages, extracted from the .astro pages
+// (rss.xml, blog/index, blog/tags/*) and the BlogPost layout, where the same
+// sort / tag-aggregation / date-format logic was duplicated inline. Structurally
+// typed rather than tied to astro:content's CollectionEntry, so they're trivial
+// to unit test with plain fixtures and reusable across every page.
+
+type DatedPost = {data: {date: Date}}
+type TaggedPost = {data: {tags?: Array<string>}}
+
+// Newest first. Returns a new array; does not mutate the input.
+export function sortPostsByDateDesc<T extends DatedPost>(posts: ReadonlyArray<T>): Array<T> {
+  return [...posts].sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+}
+
+// Every distinct tag across the posts, in first-seen order.
+export function collectTags(posts: ReadonlyArray<TaggedPost>): Array<string> {
+  const tags = new Set<string>()
+  for (const post of posts) {
+    for (const tag of post.data.tags ?? []) tags.add(tag)
+  }
+  return [...tags]
+}
+
+// [tag, count] pairs, most-used first.
+export function tagCountsDesc(posts: ReadonlyArray<TaggedPost>): Array<[string, number]> {
+  const counts = new Map<string, number>()
+  for (const post of posts) {
+    for (const tag of post.data.tags ?? []) counts.set(tag, (counts.get(tag) ?? 0) + 1)
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1])
+}
+
+// Posts carrying `tag`, newest first.
+export function postsForTag<T extends DatedPost & TaggedPost>(
+  posts: ReadonlyArray<T>,
+  tag: string,
+): Array<T> {
+  return sortPostsByDateDesc(posts.filter((post) => post.data.tags?.includes(tag)))
+}
+
+// Long-form en-US date, e.g. "December 7, 2025" -- the format shown across the
+// blog UI.
+export function formatBlogDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {year: 'numeric', month: 'long', day: 'numeric'})
+}

--- a/apps/djf.io/src/pages/blog/index.astro
+++ b/apps/djf.io/src/pages/blog/index.astro
@@ -2,10 +2,9 @@
 import {getCollection} from 'astro:content'
 import {css} from 'styled-system/css'
 import BaseLayout from '../../layouts/BaseLayout.astro'
+import {formatBlogDate, sortPostsByDateDesc} from '../../lib/blog'
 
-const posts = (await getCollection('blog')).sort(
-  (a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf(),
-)
+const posts = sortPostsByDateDesc(await getCollection('blog'))
 ---
 
 <BaseLayout title="Blog" description="Blog posts by David J Felix">
@@ -22,11 +21,7 @@ const posts = (await getCollection('blog')).sort(
   <div class={css({display: 'flex', flexDirection: 'column', gap: '6'})}>
     {
       posts.map((post) => {
-        const formattedDate = new Date(post.data.date).toLocaleDateString('en-US', {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        })
+        const formattedDate = formatBlogDate(post.data.date)
 
         return (
           <article

--- a/apps/djf.io/src/pages/blog/tags/[tag].astro
+++ b/apps/djf.io/src/pages/blog/tags/[tag].astro
@@ -2,25 +2,14 @@
 import {getCollection} from 'astro:content'
 import {css} from 'styled-system/css'
 import BaseLayout from '../../../layouts/BaseLayout.astro'
+import {collectTags, formatBlogDate, postsForTag} from '../../../lib/blog'
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog')
 
-  const tagSet = new Set<string>()
-  for (const post of posts) {
-    for (const tag of post.data.tags ?? []) {
-      tagSet.add(tag)
-    }
-  }
-
-  return [...tagSet].map((tag) => ({
+  return collectTags(posts).map((tag) => ({
     params: {tag},
-    props: {
-      tag,
-      posts: posts
-        .filter((post) => post.data.tags?.includes(tag))
-        .sort((a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf()),
-    },
+    props: {tag, posts: postsForTag(posts, tag)},
   }))
 }
 
@@ -55,11 +44,7 @@ const {tag, posts} = Astro.props
   <div class={css({display: 'flex', flexDirection: 'column', gap: '6'})}>
     {
       posts.map((post) => {
-        const formattedDate = new Date(post.data.date).toLocaleDateString('en-US', {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        })
+        const formattedDate = formatBlogDate(post.data.date)
 
         return (
           <article

--- a/apps/djf.io/src/pages/blog/tags/index.astro
+++ b/apps/djf.io/src/pages/blog/tags/index.astro
@@ -2,17 +2,9 @@
 import {getCollection} from 'astro:content'
 import {css} from 'styled-system/css'
 import BaseLayout from '../../../layouts/BaseLayout.astro'
+import {tagCountsDesc} from '../../../lib/blog'
 
-const posts = await getCollection('blog')
-
-const tagCounts = new Map<string, number>()
-for (const post of posts) {
-  for (const tag of post.data.tags ?? []) {
-    tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1)
-  }
-}
-
-const sortedTags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1])
+const sortedTags = tagCountsDesc(await getCollection('blog'))
 ---
 
 <BaseLayout title="Tags" description="Browse blog posts by tag">

--- a/apps/djf.io/src/pages/rss.xml.ts
+++ b/apps/djf.io/src/pages/rss.xml.ts
@@ -1,10 +1,11 @@
 import {getCollection} from 'astro:content'
 import rss from '@astrojs/rss'
 import type {APIContext} from 'astro'
+import {sortPostsByDateDesc} from '../lib/blog'
 
 export async function GET(context: APIContext) {
   const posts = await getCollection('blog')
-  const sortedPosts = posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  const sortedPosts = sortPostsByDateDesc(posts)
 
   return rss({
     title: "David J. Felix's Blog",

--- a/apps/djf.io/vitest.config.ts
+++ b/apps/djf.io/vitest.config.ts
@@ -4,5 +4,14 @@ export default getViteConfig({
   test: {
     include: ['src/**/*.test.ts'],
     exclude: ['**/*.e2e.test.ts', '**/node_modules/**'],
+    // Coverage gate for the app's pure logic (blog helpers + content schema).
+    // Components / pages / layouts are exercised by Playwright e2e, not unit
+    // coverage, so they are not included here.
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**', 'src/content.config.ts'],
+      reporter: ['text', 'text-summary'],
+      thresholds: {statements: 100, branches: 90, functions: 100, lines: 100},
+    },
   },
 })

--- a/apps/f311x/bin/smoke-checks.ts
+++ b/apps/f311x/bin/smoke-checks.ts
@@ -1,0 +1,75 @@
+// Shared smoke checks for f311x, used by both gates:
+//   - bin/smoke-test.ts  -- post-deploy, against prod URLs
+//   - bin/smoke-local.ts -- pre-merge, against a local wrangler-dev boot
+//
+// A URL passes when its HTML references hashed client assets, does NOT
+// reference the Vite dev virtual entry (the 2026-06-11 incident: dev-mode SSR
+// bundles shipped `/@id/virtual:tanstack-start-dev-client-entry`, which 404s in
+// production so the page never hydrated), and its client JS entry actually
+// serves. It then POSTs to the chat endpoint and requires the echo back as an
+// AG-UI SSE stream, so a hydrated shell with a dead backend -- the other half
+// of "deployed but broken" -- fails too.
+
+const DEV_ENTRY = 'virtual:tanstack-start-dev-client-entry'
+
+export async function checkUrl(url: string): Promise<string | null> {
+  const page = await fetch(url, {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `HTTP ${page.status}`
+  const html = await page.text()
+  if (html.includes(DEV_ENTRY)) return 'serves a dev-mode bundle (dev virtual entry present)'
+  const entry = html.match(/src="(\/assets\/[^"]+\.js)"/)?.[1]
+  if (!entry) return 'no hashed client JS entry in HTML'
+  const asset = await fetch(new URL(entry, url), {signal: AbortSignal.timeout(15_000)})
+  if (!asset.ok) return `client entry ${entry} -> HTTP ${asset.status}`
+  return checkChat(url)
+}
+
+// The chat loop is the whole point of the app: a hydrated shell talking to a
+// dead backend is still broken. POST an AG-UI RunAgentInput and require the echo
+// stream back -- lifecycle events plus the message echoed verbatim -- so a
+// backend regression fails the gate, not just a broken client bundle.
+async function checkChat(url: string): Promise<string | null> {
+  const sentinel = `smoke-${Math.random().toString(36).slice(2, 8)}`
+  const res = await fetch(new URL('agents/chat-agent/default', url), {
+    method: 'POST',
+    headers: {'content-type': 'application/json', accept: 'text/event-stream'},
+    body: JSON.stringify({messages: [{role: 'user', content: sentinel}]}),
+    signal: AbortSignal.timeout(15_000),
+  })
+  if (!res.ok) return `chat endpoint -> HTTP ${res.status}`
+  const body = await res.text()
+  for (const marker of ['RUN_STARTED', 'TEXT_MESSAGE_CONTENT', 'RUN_FINISHED']) {
+    if (!body.includes(marker)) return `chat stream missing ${marker}`
+  }
+  if (!body.includes(sentinel)) return 'chat stream did not echo the message back'
+  return null
+}
+
+// Check each URL, giving each a few attempts to ride out propagation. Returns
+// one `${url}: ${problem}` string per URL that never passed.
+export async function runSmoke(
+  urls: string[],
+  {attempts, retryDelayMs}: {attempts: number; retryDelayMs: number},
+): Promise<Array<string>> {
+  const failures: Array<string> = []
+  for (const url of urls) {
+    let lastProblem = 'unreachable'
+    let passed = false
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        const problem = await checkUrl(url)
+        if (problem === null) {
+          console.log(`OK: ${url} serves a production bundle`)
+          passed = true
+          break
+        }
+        lastProblem = problem
+      } catch (err) {
+        lastProblem = err instanceof Error ? err.message : String(err)
+      }
+      if (attempt < attempts) await Bun.sleep(retryDelayMs)
+    }
+    if (!passed) failures.push(`${url}: ${lastProblem}`)
+  }
+  return failures
+}

--- a/apps/f311x/bin/smoke-local.ts
+++ b/apps/f311x/bin/smoke-local.ts
@@ -84,7 +84,8 @@ try {
   }
 } finally {
   worker.kill()
-  await worker.exited.catch(() => {})
+  await Promise.race([worker.exited, Bun.sleep(3_000)])
+  worker.kill('SIGKILL')
 }
 
 process.exit(exitCode)

--- a/apps/f311x/bin/smoke-local.ts
+++ b/apps/f311x/bin/smoke-local.ts
@@ -1,0 +1,90 @@
+// Pre-merge smoke gate: boots the *built* worker locally under workerd (via
+// `wrangler dev`) and runs the same checks the post-deploy gate runs against
+// prod. Because it serves the real production server bundle (dist/server) on the
+// Workers runtime, it catches the "deployed but broken" class of failure -- a
+// dead chat backend or a dev-mode bundle -- before merge, not after.
+//
+// Deterministic: the chat agent is an echo stub, so no credentials or model
+// access are needed. Assumes `vite build` has run (the `smoke` mise task
+// depends on `build`); compatibility settings are read from wrangler.toml so
+// the local runtime matches the deployed one.
+
+import {existsSync} from 'node:fs'
+import wrangler from '../wrangler.toml'
+import {runSmoke} from './smoke-checks'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4311)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const WORKER = 'dist/server/server.js'
+const ASSETS = 'dist/client'
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync(WORKER)) {
+  console.error(`::error::${WORKER} is missing -- run \`mise run build\` first`)
+  process.exit(1)
+}
+
+const flags: Array<string> = wrangler.compatibility_flags ?? []
+const worker = Bun.spawn(
+  [
+    'pnpm',
+    'exec',
+    'wrangler',
+    'dev',
+    WORKER,
+    '--port',
+    String(PORT),
+    '--ip',
+    '127.0.0.1',
+    '--assets',
+    ASSETS,
+    '--compatibility-date',
+    wrangler.compatibility_date,
+    ...(flags.length > 0 ? ['--compatibility-flags', flags.join(',')] : []),
+  ],
+  {
+    env: {...process.env, CI: 'true', WRANGLER_SEND_METRICS: 'false'},
+    stdout: 'ignore',
+    stderr: 'inherit',
+  },
+)
+
+let exitCode = 0
+try {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  let ready = false
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) {
+        ready = true
+        break
+      }
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+
+  if (!ready) {
+    console.error(
+      `::error::worker did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    // One real attempt locally -- there is no deployment propagation to wait
+    // out -- plus a single retry to absorb a cold first request.
+    const failures = await runSmoke([BASE_URL], {attempts: 2, retryDelayMs: 1_000})
+    if (failures.length > 0) {
+      for (const failure of failures) console.error(`::error::smoke test failed — ${failure}`)
+      exitCode = 1
+    } else {
+      console.log('f311x local smoke passed')
+    }
+  }
+} finally {
+  worker.kill()
+  await worker.exited.catch(() => {})
+}
+
+process.exit(exitCode)

--- a/apps/f311x/bin/smoke-local.ts
+++ b/apps/f311x/bin/smoke-local.ts
@@ -25,11 +25,13 @@ if (!existsSync(WORKER)) {
 }
 
 const flags: Array<string> = wrangler.compatibility_flags ?? []
+// Spawn the wrangler binary directly (not via `pnpm exec`): killing the pnpm
+// wrapper does not cascade to wrangler/workerd, which would then outlive
+// teardown and keep holding the port -- the same trap the other smoke scripts
+// avoid by spawning node_modules/.bin/... directly.
 const worker = Bun.spawn(
   [
-    'pnpm',
-    'exec',
-    'wrangler',
+    'node_modules/.bin/wrangler',
     'dev',
     WORKER,
     '--port',

--- a/apps/f311x/bin/smoke-test.ts
+++ b/apps/f311x/bin/smoke-test.ts
@@ -1,78 +1,22 @@
-// Post-deploy gate: proves prod is serving a working production bundle
-// instead of trusting deploy exit codes (which the alchemy CLI's
-// hang-after-success makes unreliable — see bin/deploy-prod.ts).
+// Post-deploy gate: proves prod is serving a working production bundle instead
+// of trusting deploy exit codes (which the alchemy CLI's hang-after-success
+// makes unreliable -- see bin/deploy-prod.ts). The checks themselves live in
+// bin/smoke-checks.ts and are shared with the pre-merge gate, bin/smoke-local.ts.
 //
-// A page passes when its HTML references hashed client assets, does NOT
-// reference the Vite dev virtual entry (the 2026-06-11 incident: dev-mode
-// SSR bundles shipped `/@id/virtual:tanstack-start-dev-client-entry`, which
-// 404s in production so the page never hydrates), and its client JS entry
-// actually serves. It then POSTs to the chat endpoint and requires the echo
-// back as an AG-UI SSE stream, so a hydrated shell with a dead backend (the
-// other half of "deployed but broken") fails the gate too. Each URL gets a
-// few attempts to ride out propagation.
+// Each URL gets several attempts to ride out DNS / edge propagation after a
+// deploy. Override the targets and timing with SMOKE_URLS / SMOKE_ATTEMPTS /
+// SMOKE_RETRY_DELAY_MS.
 
-const DEV_ENTRY = 'virtual:tanstack-start-dev-client-entry'
-const ATTEMPTS = Number(process.env.SMOKE_ATTEMPTS ?? 6)
-const RETRY_DELAY_MS = Number(process.env.SMOKE_RETRY_DELAY_MS ?? 10_000)
+import {runSmoke} from './smoke-checks'
+
 const urls = (
   process.env.SMOKE_URLS ??
   'https://f311x-website-prod-ddptpca6nyzpodvc.nullserve.workers.dev/,https://f311x.com/'
 ).split(',')
+const attempts = Number(process.env.SMOKE_ATTEMPTS ?? 6)
+const retryDelayMs = Number(process.env.SMOKE_RETRY_DELAY_MS ?? 10_000)
 
-const failures: string[] = []
-
-async function check(url: string): Promise<string | null> {
-  const page = await fetch(url, {signal: AbortSignal.timeout(15_000)})
-  if (!page.ok) return `HTTP ${page.status}`
-  const html = await page.text()
-  if (html.includes(DEV_ENTRY)) return 'serves a dev-mode bundle (dev virtual entry present)'
-  const entry = html.match(/src="(\/assets\/[^"]+\.js)"/)?.[1]
-  if (!entry) return 'no hashed client JS entry in HTML'
-  const asset = await fetch(new URL(entry, url), {signal: AbortSignal.timeout(15_000)})
-  if (!asset.ok) return `client entry ${entry} -> HTTP ${asset.status}`
-  return checkChat(url)
-}
-
-// The chat loop is the whole point of the app: a hydrated shell talking to a
-// dead backend is still broken. POST an AG-UI RunAgentInput and require the
-// echo stream back — lifecycle events plus the message echoed verbatim — so a
-// backend regression fails the gate, not just a broken client bundle.
-async function checkChat(url: string): Promise<string | null> {
-  const sentinel = `smoke-${Math.random().toString(36).slice(2, 8)}`
-  const res = await fetch(new URL('agents/chat-agent/default', url), {
-    method: 'POST',
-    headers: {'content-type': 'application/json', accept: 'text/event-stream'},
-    body: JSON.stringify({messages: [{role: 'user', content: sentinel}]}),
-    signal: AbortSignal.timeout(15_000),
-  })
-  if (!res.ok) return `chat endpoint -> HTTP ${res.status}`
-  const body = await res.text()
-  for (const marker of ['RUN_STARTED', 'TEXT_MESSAGE_CONTENT', 'RUN_FINISHED']) {
-    if (!body.includes(marker)) return `chat stream missing ${marker}`
-  }
-  if (!body.includes(sentinel)) return 'chat stream did not echo the message back'
-  return null
-}
-
-for (const url of urls) {
-  let lastProblem = 'unreachable'
-  let passed = false
-  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
-    try {
-      const problem = await check(url)
-      if (problem === null) {
-        console.log(`OK: ${url} serves a production bundle`)
-        passed = true
-        break
-      }
-      lastProblem = problem
-    } catch (err) {
-      lastProblem = err instanceof Error ? err.message : String(err)
-    }
-    if (attempt < ATTEMPTS) await Bun.sleep(RETRY_DELAY_MS)
-  }
-  if (!passed) failures.push(`${url}: ${lastProblem}`)
-}
+const failures = await runSmoke(urls, {attempts, retryDelayMs})
 
 if (failures.length > 0) {
   for (const failure of failures) console.error(`::error::smoke test failed — ${failure}`)

--- a/apps/f311x/mise.toml
+++ b/apps/f311x/mise.toml
@@ -27,6 +27,11 @@ run = "pnpm run test"
 description = "Build with Vite"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (workerd via wrangler dev)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/f311x/package.json
+++ b/apps/f311x/package.json
@@ -17,7 +17,7 @@
     "format:fix": "biome format --write . && prettier --write --no-error-on-unmatched-pattern \"**/*.md\" \"**/*.mdx\"",
     "spell": "cspell --config ../../.config/cspell.json \"**\"",
     "typecheck": "tsgo --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -63,6 +63,7 @@
     "@types/react-dom": "19.2.3",
     "@typescript/native-preview": "latest",
     "@vitejs/plugin-react": "6.0.2",
+    "@vitest/coverage-v8": "4.1.8",
     "jsdom": "29.1.1",
     "vite": "8.0.16",
     "vitest": "4.1.8",

--- a/apps/f311x/pnpm-lock.yaml
+++ b/apps/f311x/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
       alchemy:
         specifier: 2.0.0-beta.55
-        version: 2.0.0-beta.55(@effect/platform-node@4.0.0-beta.83(effect@4.0.0-beta.83)(ioredis@5.11.1))(@types/node@25.9.3)(@types/react@19.2.17)(effect@4.0.0-beta.83)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260611.1)(ws@8.21.0)
+        version: 2.0.0-beta.55(@effect/platform-node@4.0.0-beta.83(effect@4.0.0-beta.83)(ioredis@5.11.1))(@types/node@25.9.3)(@types/react@19.2.17)(effect@4.0.0-beta.83)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)(workerd@1.20260611.1)(ws@8.21.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -138,6 +138,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       jsdom:
         specifier: 29.1.1
         version: 29.1.1(@noble/hashes@1.8.0)
@@ -146,7 +149,7 @@ importers:
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
       wrangler:
         specifier: 4.100.0
         version: 4.100.0(@cloudflare/workers-types@4.20260613.1)
@@ -407,6 +410,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -2803,6 +2810,15 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -2927,6 +2943,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
@@ -3527,6 +3546,10 @@ packages:
       crossws:
         optional: true
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -3548,6 +3571,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -3731,6 +3757,18 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -3740,6 +3778,9 @@ packages:
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3922,6 +3963,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -4757,6 +4805,10 @@ packages:
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -5654,6 +5706,8 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -5859,10 +5913,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.83(effect@4.0.0-beta.83)(vitest@4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.83(effect@4.0.0-beta.83)(vitest@4.1.8)':
     dependencies:
       effect: 4.0.0-beta.83
-      vitest: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -7867,6 +7921,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)
 
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -7926,7 +7994,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alchemy@2.0.0-beta.55(@effect/platform-node@4.0.0-beta.83(effect@4.0.0-beta.83)(ioredis@5.11.1))(@types/node@25.9.3)(@types/react@19.2.17)(effect@4.0.0-beta.83)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))(workerd@1.20260611.1)(ws@8.21.0):
+  alchemy@2.0.0-beta.55(@effect/platform-node@4.0.0-beta.83(effect@4.0.0-beta.83)(ioredis@5.11.1))(@types/node@25.9.3)(@types/react@19.2.17)(effect@4.0.0-beta.83)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.8)(workerd@1.20260611.1)(ws@8.21.0):
     dependencies:
       '@alchemy.run/node-utils': 0.0.5
       '@aws-sdk/credential-providers': 3.1068.0
@@ -7940,7 +8008,7 @@ snapshots:
       '@distilled.cloud/core': 0.24.9(effect@4.0.0-beta.83)
       '@distilled.cloud/neon': 0.24.9(effect@4.0.0-beta.83)
       '@distilled.cloud/planetscale': 0.24.9(effect@4.0.0-beta.83)
-      '@effect/vitest': 4.0.0-beta.83(effect@4.0.0-beta.83)(vitest@4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)))
+      '@effect/vitest': 4.0.0-beta.83(effect@4.0.0-beta.83)(vitest@4.1.8)
       '@libsql/client': 0.17.3
       '@octokit/rest': 22.0.1
       '@smithy/node-config-provider': 4.4.7
@@ -8011,6 +8079,12 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   auto-bind@5.0.1: {}
 
@@ -8596,6 +8670,8 @@ snapshots:
       rou3: 0.8.1
       srvx: 0.11.16
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.4:
@@ -8633,6 +8709,8 @@ snapshots:
       '@exodus/bytes': 1.15.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
 
@@ -8795,11 +8873,26 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
 
   js-base64@3.7.8: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -8971,6 +9064,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.4
 
   markdown-table@3.0.4: {}
 
@@ -10198,6 +10301,10 @@ snapshots:
 
   supports-color@10.2.2: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   symbol-tree@3.2.4: {}
 
   tagged-tag@1.0.0: {}
@@ -10400,7 +10507,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)
 
-  vitest@4.1.8(@types/node@25.9.3)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
@@ -10424,6 +10531,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw

--- a/apps/f311x/vitest.config.ts
+++ b/apps/f311x/vitest.config.ts
@@ -9,5 +9,14 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     include: ['src/**/*.test.{ts,tsx}'],
+    // Coverage gate for the app's pure logic (the chat agent). The UI / route /
+    // worker glue is exercised by smoke + e2e, not unit coverage, so it is not
+    // included here.
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/**'],
+      reporter: ['text', 'text-summary'],
+      thresholds: {statements: 100, branches: 90, functions: 100, lines: 100},
+    },
   },
 })

--- a/apps/forzamonica.com/bin/smoke-local.ts
+++ b/apps/forzamonica.com/bin/smoke-local.ts
@@ -1,0 +1,85 @@
+/// <reference types="bun" />
+// Pre-merge smoke gate: boots the production build and checks the critical path
+// serves a working bundle -- each route returns 200, the response is a complete
+// HTML document, and any hashed client asset it references itself serves.
+//
+// forzamonica.com is a TanStack Start app on Cloudflare Workers; its
+// @cloudflare/vite-plugin makes `vite preview` serve the built worker (SSR) in
+// workerd, so `/` exercises the real storefront render path (the Shopify
+// Storefront API, mock.shop in dev). Catches the "deployed but broken" class
+// before merge. Assumes `vite build` has run (the `smoke` task depends on
+// `build`); parameterized via SMOKE_ROUTES / SMOKE_PORT.
+
+import {existsSync} from 'node:fs'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4173)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const ROUTES = (process.env.SMOKE_ROUTES ?? '/').split(',')
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync('dist')) {
+  console.error('::error::dist is missing -- run `mise run build` first')
+  process.exit(1)
+}
+
+// Spawn the preview binary directly (not through `pnpm run`): killing the pnpm
+// wrapper does not cascade to the server, so it would outlive teardown and hold
+// the port. Detached stdio keeps the server from holding this process's pipes
+// open, which would otherwise stall a `... | tail` pipeline after we exit.
+const server = Bun.spawn(
+  ['node_modules/.bin/vite', 'preview', '--host', '127.0.0.1', '--port', String(PORT)],
+  {env: {...process.env, CI: 'true'}, stdout: 'ignore', stderr: 'ignore'},
+)
+
+async function check(route: string): Promise<string | null> {
+  const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `${route} -> HTTP ${page.status}`
+  const html = await page.text()
+  if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
+  if (asset) {
+    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
+  }
+  return null
+}
+
+async function waitForReady(): Promise<boolean> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) return true
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+  return false
+}
+
+let exitCode = 0
+try {
+  if (!(await waitForReady())) {
+    console.error(
+      `::error::preview did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    for (const route of ROUTES) {
+      const problem = await check(route)
+      if (problem === null) {
+        console.log(`OK: ${route} serves a working bundle`)
+      } else {
+        console.error(`::error::smoke test failed — ${problem}`)
+        exitCode = 1
+      }
+    }
+  }
+} finally {
+  server.kill()
+  await Promise.race([server.exited, Bun.sleep(3_000)])
+  server.kill('SIGKILL')
+}
+
+process.exit(exitCode)

--- a/apps/forzamonica.com/mise.toml
+++ b/apps/forzamonica.com/mise.toml
@@ -25,6 +25,11 @@ run = "pnpm run test"
 description = "Build with Vite"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (vite preview on workerd)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/forzamonica.com/package.json
+++ b/apps/forzamonica.com/package.json
@@ -17,7 +17,7 @@
     "format:fix": "biome format --write . && prettier --write --no-error-on-unmatched-pattern \"**/*.md\" \"**/*.mdx\"",
     "spell": "cspell --config ../../.config/cspell.json \"**\"",
     "typecheck": "tsgo --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -39,6 +39,7 @@
     "@types/react-dom": "19.2.3",
     "@typescript/native-preview": "latest",
     "@vitejs/plugin-react": "6.0.2",
+    "@vitest/coverage-v8": "4.1.8",
     "jsdom": "29.1.1",
     "vite": "8.0.16",
     "vitest": "4.1.8",

--- a/apps/forzamonica.com/package.json
+++ b/apps/forzamonica.com/package.json
@@ -34,6 +34,7 @@
     "@cloudflare/workers-types": "4.20260613.1",
     "@pandacss/dev": "1.11.3",
     "@tanstack/devtools-vite": "latest",
+    "@types/bun": "1.3.14",
     "@types/node": "25.9.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/apps/forzamonica.com/pnpm-lock.yaml
+++ b/apps/forzamonica.com/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       jsdom:
         specifier: 29.1.1
         version: 29.1.1
@@ -65,7 +68,7 @@ importers:
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
       wrangler:
         specifier: 4.100.0
         version: 4.100.0(@cloudflare/workers-types@4.20260613.1)
@@ -163,6 +166,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -1499,6 +1506,15 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -1814,6 +1830,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -2189,6 +2208,10 @@ packages:
       crossws:
         optional: true
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2204,6 +2227,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2253,6 +2279,18 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
 
@@ -2262,6 +2300,9 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2471,6 +2512,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2865,6 +2913,10 @@ packages:
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3387,6 +3439,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -4593,6 +4647,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)
 
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -5263,6 +5331,12 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-v8-to-istanbul@1.0.4:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   astral-regex@2.0.0: {}
 
   babel-dead-code-elimination@1.0.12:
@@ -5668,6 +5742,8 @@ snapshots:
       rou3: 0.8.1
       srvx: 0.11.16
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.4:
@@ -5681,6 +5757,8 @@ snapshots:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -5718,11 +5796,26 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   javascript-stringify@2.1.0: {}
 
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5890,6 +5983,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.4
 
   math-intrinsics@1.1.0: {}
 
@@ -6307,6 +6410,10 @@ snapshots:
 
   supports-color@10.2.2: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   symbol-tree@3.2.4: {}
 
   table@6.9.0:
@@ -6435,7 +6542,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)
 
-  vitest@4.1.8(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)):
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
@@ -6459,6 +6566,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw

--- a/apps/forzamonica.com/pnpm-lock.yaml
+++ b/apps/forzamonica.com/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@tanstack/devtools-vite':
         specifier: latest
         version: 0.7.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/node':
         specifier: 25.9.3
         version: 25.9.3
@@ -1423,6 +1426,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1877,6 +1883,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -4588,6 +4597,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -5395,6 +5408,10 @@ snapshots:
       electron-to-chromium: 1.5.372
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.9.3
 
   bytes@3.1.2: {}
 

--- a/apps/forzamonica.com/vitest.config.ts
+++ b/apps/forzamonica.com/vitest.config.ts
@@ -9,5 +9,13 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     include: ['src/**/*.test.{ts,tsx}'],
+    // Coverage gate scoped to the tested logic (price formatting). The rest of
+    // src/lib is untested for now; widen `include` as those modules get tests.
+    coverage: {
+      provider: 'v8',
+      include: ['src/lib/format-price.ts'],
+      reporter: ['text', 'text-summary'],
+      thresholds: {statements: 100, branches: 90, functions: 100, lines: 100},
+    },
   },
 })

--- a/apps/ravrun/bin/smoke-local.ts
+++ b/apps/ravrun/bin/smoke-local.ts
@@ -1,0 +1,84 @@
+/// <reference types="bun" />
+// Pre-merge smoke gate: boots the production preview server and checks the
+// critical path serves a working bundle -- each route returns 200, the response
+// is a complete HTML document, and any hashed client asset it references itself
+// serves. Catches the "deployed but broken" class (route 404/500, missing
+// assets) before merge. Deterministic and secret-free.
+//
+// Assumes `vite build` has run (the `smoke` mise task depends on `build`). The
+// gate is parameterized (SMOKE_ROUTES / SMOKE_PORT) so the same checks can later
+// target a per-PR preview deploy.
+
+import {existsSync} from 'node:fs'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4173)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const ROUTES = (process.env.SMOKE_ROUTES ?? '/').split(',')
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync('dist')) {
+  console.error('::error::dist is missing -- run `mise run build` first')
+  process.exit(1)
+}
+
+// Spawn the preview binary directly (not through `pnpm run`): killing the pnpm
+// wrapper does not cascade to the server, so it would outlive teardown and hold
+// the port. Detached stdio keeps the server from holding this process's pipes
+// open, which would otherwise stall a `... | tail` pipeline after we exit.
+const server = Bun.spawn(
+  ['node_modules/.bin/vite', 'preview', '--host', '127.0.0.1', '--port', String(PORT)],
+  {env: {...process.env, CI: 'true'}, stdout: 'ignore', stderr: 'ignore'},
+)
+
+async function check(route: string): Promise<string | null> {
+  const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `${route} -> HTTP ${page.status}`
+  const html = await page.text()
+  if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
+  if (asset) {
+    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
+  }
+  return null
+}
+
+async function waitForReady(): Promise<boolean> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) return true
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+  return false
+}
+
+let exitCode = 0
+try {
+  if (!(await waitForReady())) {
+    console.error(
+      `::error::preview did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    for (const route of ROUTES) {
+      const problem = await check(route)
+      if (problem === null) {
+        console.log(`OK: ${route} serves a working bundle`)
+      } else {
+        console.error(`::error::smoke test failed — ${problem}`)
+        exitCode = 1
+      }
+    }
+  }
+} finally {
+  server.kill()
+  await Promise.race([server.exited, Bun.sleep(3_000)])
+  server.kill('SIGKILL')
+}
+
+process.exit(exitCode)

--- a/apps/ravrun/mise.toml
+++ b/apps/ravrun/mise.toml
@@ -25,6 +25,11 @@ run = "pnpm run test"
 description = "Build with Vite"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (vite preview)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/ravrun/package.json
+++ b/apps/ravrun/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@cspell/dict-typescript": "3.2.3",
     "@tanstack/router-plugin": "1.168.18",
+    "@types/bun": "1.3.14",
     "@types/node": "25.9.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/apps/ravrun/pnpm-lock.yaml
+++ b/apps/ravrun/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: 1.168.18
         version: 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/node':
         specifier: 25.9.3
         version: 25.9.3
@@ -1035,6 +1038,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1177,6 +1183,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
@@ -2684,6 +2693,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2814,6 +2827,10 @@ snapshots:
       electron-to-chromium: 1.5.372
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.9.3
 
   caniuse-lite@1.0.30001799: {}
 

--- a/bin/run-app-tasks.ts
+++ b/bin/run-app-tasks.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env bun
+// Runs one mise task across every app in apps/, in series, and prints a pass/
+// fail summary -- the engine behind the root `test` / `check` aggregators, so the
+// whole monorepo can be verified with a single command. Per-app CI still runs
+// each app's tasks on path-filtered triggers; this is the local "check
+// everything before I push" path.
+//
+// Sets CI=true for each sub-run so pnpm's verify-deps-before-run won't abort on a
+// drifted node_modules in a non-interactive shell
+// (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
+
+import {existsSync, readdirSync} from 'node:fs'
+
+const task = process.argv[2] ?? 'test'
+const appsDir = 'apps'
+
+const apps = readdirSync(appsDir, {withFileTypes: true})
+  .filter((entry) => entry.isDirectory() && existsSync(`${appsDir}/${entry.name}/mise.toml`))
+  .map((entry) => entry.name)
+  .sort()
+
+const results: Array<{app: string; ok: boolean}> = []
+for (const app of apps) {
+  console.log(`\n=== ${app}: mise run ${task} ===`)
+  const proc = Bun.spawn(['mise', 'run', task], {
+    cwd: `${appsDir}/${app}`,
+    env: {...process.env, CI: 'true'},
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  results.push({app, ok: (await proc.exited) === 0})
+}
+
+console.log('\n=== summary ===')
+for (const result of results) console.log(`${result.ok ? 'ok  ' : 'FAIL'} ${result.app}`)
+
+const failed = results.filter((result) => !result.ok)
+if (failed.length > 0) {
+  console.error(
+    `\n${failed.length} app(s) failed: ${failed.map((result) => result.app).join(', ')}`,
+  )
+  process.exit(1)
+}
+console.log(`\nall ${results.length} apps passed \`${task}\``)

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -20,6 +20,12 @@ Per-PR preview deployments, smoke tests, and screenshot testing for every deploy
 
 **Status**: In Progress
 
+### [Testing Harness & Code-Quality Safety Net](./projects/testing-harness/plan.md)
+
+A layered, fast safety net (unit -> smoke -> e2e -> coverage) that also runs inside Claude Code on the web, not just CI. Phase 0 (web-session bootstrap hook) is done; smoke-test pull-forward, generalization, unit-test backfill, and a repo-wide coverage gate follow. Complements preview-deployments (preview infra) and sentry-integration (diagnosis).
+
+**Status**: In Progress
+
 ## Priority 2 — Monorepo Hygiene
 
 ### [Linter & Formatter Standardization](./projects/linter-formatter-standardization/plan.md)

--- a/docs/projects/testing-harness/2026-06-14-progress.md
+++ b/docs/projects/testing-harness/2026-06-14-progress.md
@@ -43,8 +43,27 @@ not build, test, or boot any app at all. Set up the web-session bootstrap
 - Refactor `bin/smoke-test.ts` into a reusable checks module; add a
   `mise run smoke` task (local boot) + a CI job on PRs.
 
+## Phase 1 complete -- f311x smoke -> pre-merge
+
+- Spiked the local boot: `vite preview` is static-only (no SSR), and the built
+  `dist/server/server.js` is a Worker `fetch` module -- so the faithful local
+  boot is `wrangler dev` on the built worker (workerd), which serves SSR plus
+  the chat route. Verified the chat endpoint streams the echo locally.
+- Refactored the checks into `bin/smoke-checks.ts`, now shared by the post-deploy
+  gate (`bin/smoke-test.ts`, prod URLs) and the new pre-merge gate
+  (`bin/smoke-local.ts`, local workerd boot).
+- Added `mise run smoke` (depends on `build`) and a `smoke` CI job in
+  ci-f311x.yml. Green locally (~8s); typecheck / lint / format / actionlint /
+  ghalint all pass.
+
+## Next steps
+
+- Phase 2: extract the `smoke` task contract + a short testing guide, then roll
+  it to djf.io, calendar-visualizer, davidjfelix.com, ravrun.
+- Optional higher fidelity: point `SMOKE_URLS` at a real per-PR preview deploy
+  (preview-deployments project); the gate already supports it.
+
 ## Open questions / blockers
 
-- `vite preview` vs `wrangler dev` for the f311x local smoke boot (spike above).
 - Whether to fold full per-PR preview deploys + the f311x Sentry slice into this
-  push or sequence them after the local smoke pattern is proven.
+  push or sequence them after the pattern is generalized (Phase 2).

--- a/docs/projects/testing-harness/2026-06-14-progress.md
+++ b/docs/projects/testing-harness/2026-06-14-progress.md
@@ -56,14 +56,32 @@ not build, test, or boot any app at all. Set up the web-session bootstrap
   ci-f311x.yml. Green locally (~8s); typecheck / lint / format / actionlint /
   ghalint all pass.
 
+## Phase 2 complete -- generalize the smoke pattern
+
+- Wrote the durable `smoke` contract into CLAUDE.md (Testing Conventions ->
+  Runtime checks): build -> boot the production build -> assert the critical
+  path; boot per stack (Astro `astro preview`, Vite `vite preview`, Worker
+  `wrangler dev`); spawn the preview binary directly so teardown actually kills
+  it.
+- Added `bin/smoke-local.ts` + `smoke` task + `smoke` CI job to
+  calendar-visualizer, davidjfelix.com (static Astro) and ravrun (Vite SPA).
+  All three `mise run smoke` green locally; typecheck / lint / format /
+  actionlint / ghalint all pass.
+- Added `@types/bun` to those three apps and a `/// <reference types="bun" />`
+  in each smoke script -- the reliable way to get the `Bun` global across their
+  differing tsconfigs (astro-extends vs bare tsgo).
+- djf.io keeps its Playwright e2e as its runtime gate (a superset of smoke), per
+  the contract.
+
 ## Next steps
 
-- Phase 2: extract the `smoke` task contract + a short testing guide, then roll
-  it to djf.io, calendar-visualizer, davidjfelix.com, ravrun.
+- Phase 3: backfill real unit tests where logic lives (djf.io content config /
+  SEO, calendar-visualizer state).
+- Phase 4: repo-wide test + coverage gate.
 - Optional higher fidelity: point `SMOKE_URLS` at a real per-PR preview deploy
   (preview-deployments project); the gate already supports it.
 
 ## Open questions / blockers
 
 - Whether to fold full per-PR preview deploys + the f311x Sentry slice into this
-  push or sequence them after the pattern is generalized (Phase 2).
+  push or sequence them after Phases 3-4.

--- a/docs/projects/testing-harness/2026-06-14-progress.md
+++ b/docs/projects/testing-harness/2026-06-14-progress.md
@@ -101,11 +101,12 @@ not build, test, or boot any app at all. Set up the web-session bootstrap
 
 ## Project status
 
-Phases 0-4 (the original plan) are DONE. The testing harness is in place:
-bootstrap -> unit (+coverage) -> smoke -> e2e, runnable in web sessions and CI.
-Remaining are follow-ups, not core plan:
+Phases 0-4 (the original plan) are DONE, and the v8 coverage gate now covers all
+four apps with real unit tests -- f311x, djf.io, calendar-visualizer
+(`calendar-state.ts`), forzamonica.com (`format-price.ts`). The testing harness
+is in place: bootstrap -> unit (+coverage) -> smoke -> e2e, runnable in web
+sessions and CI. Remaining follow-ups:
 
-- Coverage for calendar-visualizer + forzamonica.com (same recipe).
 - Confirm which of the other apps (forzamonica.com, monicandavid.com,
   onvibes.org, pkg.dog, revision.city, startchi.com) are deployed and need smoke.
 - Durable pnpm purge-papercut fix (root `.npmrc` `confirm-modules-purge=false`)

--- a/docs/projects/testing-harness/2026-06-14-progress.md
+++ b/docs/projects/testing-harness/2026-06-14-progress.md
@@ -86,13 +86,35 @@ not build, test, or boot any app at all. Set up the web-session bootstrap
 - Hit the pnpm purge papercut again (see open questions): `mise run <task>`
   needs `CI=true` in a web session or pnpm aborts the deps check with no TTY.
 
-## Next steps
+## Phase 4 complete -- repo-wide test + coverage gate
 
-- Phase 4: repo-wide test + coverage gate.
-- Optional higher fidelity: point `SMOKE_URLS` at a real per-PR preview deploy
-  (preview-deployments project); the gate already supports it.
-- Possible quick win: durable fix for the pnpm purge papercut (root `.npmrc`
-  `confirm-modules-purge=false`).
+- Root aggregator: `bin/run-app-tasks.ts` (bun) behind root `mise run test` /
+  `mise run check` fans a task across all 11 apps with `CI=true` and prints a
+  pass/fail summary. Validated: 10/11 pass `test`; djf.io's only "failure" is its
+  Playwright e2e needing browsers not installed locally (`playwright install`) --
+  CI installs them, and the aggregator sets `CI=true` so the pnpm papercut can't
+  bite.
+- Coverage gates: vitest v8, scoped to pure logic, enforced via `--coverage`.
+  f311x (`src/lib/**`): 100/92/100/100. djf.io (`src/lib/**` + content.config):
+  100/100/100/100. Ratchet thresholds (100 stmts/funcs/lines, 90 branches).
+- Documented the coverage recipe + the aggregator in CLAUDE.md.
+
+## Project status
+
+Phases 0-4 (the original plan) are DONE. The testing harness is in place:
+bootstrap -> unit (+coverage) -> smoke -> e2e, runnable in web sessions and CI.
+Remaining are follow-ups, not core plan:
+
+- Coverage for calendar-visualizer + forzamonica.com (same recipe).
+- Confirm which of the other apps (forzamonica.com, monicandavid.com,
+  onvibes.org, pkg.dog, revision.city, startchi.com) are deployed and need smoke.
+- Durable pnpm purge-papercut fix (root `.npmrc` `confirm-modules-purge=false`)
+  so single manual `mise run <task>` works without `CI=true`.
+- Optional: install Playwright browsers in the SessionStart hook so djf.io e2e
+  runs in web sessions; point `SMOKE_URLS` at a per-PR preview deploy.
+
+Consider closing the project per CLAUDE.md (changelog + delete dir) once the
+follow-ups are triaged.
 
 ## Open questions / blockers
 

--- a/docs/projects/testing-harness/2026-06-14-progress.md
+++ b/docs/projects/testing-harness/2026-06-14-progress.md
@@ -99,16 +99,31 @@ not build, test, or boot any app at all. Set up the web-session bootstrap
   100/100/100/100. Ratchet thresholds (100 stmts/funcs/lines, 90 branches).
 - Documented the coverage recipe + the aggregator in CLAUDE.md.
 
+## Smoke: forzamonica.com + deployed-app audit
+
+Audited the six apps without smoke for deploy status: **only forzamonica.com is
+actually deployed** (it has `cd-deploy-forzamonica-com.yml`). monicandavid.com,
+onvibes.org, pkg.dog, revision.city and startchi.com have `deploy` scripts +
+wrangler.toml but **no CD workflow** -- placeholders, out of scope until they're
+wired to deploy.
+
+Added smoke to forzamonica.com (the deployed app that lacked it). It's a
+TanStack Start worker, but its `@cloudflare/vite-plugin` makes `vite preview`
+serve the built worker (SSR) in workerd -- so it uses the same `vite preview`
+recipe as ravrun (no special wrangler-dev boot needed). `mise run smoke` checks
+`/` (which SSRs the Shopify storefront via mock.shop). Green locally (~8s);
+typecheck / lint / format / actionlint pass. Added `@types/bun` +
+`/// <reference types="bun" />` like the other smoke apps. **Every deployed app
+now has a runtime gate (smoke or e2e).**
+
 ## Project status
 
-Phases 0-4 (the original plan) are DONE, and the v8 coverage gate now covers all
-four apps with real unit tests -- f311x, djf.io, calendar-visualizer
-(`calendar-state.ts`), forzamonica.com (`format-price.ts`). The testing harness
-is in place: bootstrap -> unit (+coverage) -> smoke -> e2e, runnable in web
-sessions and CI. Remaining follow-ups:
+Phases 0-4 (the original plan) are DONE; the v8 coverage gate covers all four
+apps with real unit tests (f311x, djf.io, calendar-visualizer, forzamonica.com);
+and every deployed app has a smoke/e2e gate. The testing harness is in place:
+bootstrap -> unit (+coverage) -> smoke -> e2e, runnable in web sessions and CI.
+Remaining follow-ups:
 
-- Confirm which of the other apps (forzamonica.com, monicandavid.com,
-  onvibes.org, pkg.dog, revision.city, startchi.com) are deployed and need smoke.
 - Durable pnpm purge-papercut fix (root `.npmrc` `confirm-modules-purge=false`)
   so single manual `mise run <task>` works without `CI=true`.
 - Optional: install Playwright browsers in the SessionStart hook so djf.io e2e
@@ -121,6 +136,9 @@ follow-ups are triaged.
 
 - Whether to fold full per-PR preview deploys + the f311x Sentry slice into this
   push or sequence them after Phase 4.
-- Several apps beyond the five analyzed (forzamonica.com, monicandavid.com,
-  onvibes.org, pkg.dog, revision.city, startchi.com) -- confirm which are
-  deployed and need a smoke gate too.
+- ~~Which other apps are deployed and need smoke?~~ Resolved: audited all six;
+  only forzamonica.com was deployed (now has smoke). monicandavid.com,
+  onvibes.org, pkg.dog, revision.city, startchi.com are placeholders with no CD
+  workflow -- add smoke when they're wired to deploy (recipe per stack: Astro
+  static -> astro preview; Vite/TanStack-on-CF -> vite preview; SvelteKit/Nuxt
+  -> wrangler dev on the built worker).

--- a/docs/projects/testing-harness/2026-06-14-progress.md
+++ b/docs/projects/testing-harness/2026-06-14-progress.md
@@ -73,15 +73,31 @@ not build, test, or boot any app at all. Set up the web-session bootstrap
 - djf.io keeps its Playwright e2e as its runtime gate (a superset of smoke), per
   the contract.
 
+## Phase 3 complete -- backfill real unit tests
+
+- djf.io: extracted the blog list / tag logic (date sort, tag collect / count /
+  filter, date format) -- duplicated inline across rss.xml, blog/index,
+  blog/tags/* and the BlogPost layout -- into a pure `src/lib/blog.ts`,
+  refactored all five call sites to use it, and added `src/lib/blog.test.ts`
+  (11 tests). 44 unit tests pass; typecheck / lint / format / build all green
+  (17 pages).
+- calendar-visualizer's core (`getCalendarDisplayState`) was already covered
+  (11 tests); skipped the low-value component-local `getDayVariant`.
+- Hit the pnpm purge papercut again (see open questions): `mise run <task>`
+  needs `CI=true` in a web session or pnpm aborts the deps check with no TTY.
+
 ## Next steps
 
-- Phase 3: backfill real unit tests where logic lives (djf.io content config /
-  SEO, calendar-visualizer state).
 - Phase 4: repo-wide test + coverage gate.
 - Optional higher fidelity: point `SMOKE_URLS` at a real per-PR preview deploy
   (preview-deployments project); the gate already supports it.
+- Possible quick win: durable fix for the pnpm purge papercut (root `.npmrc`
+  `confirm-modules-purge=false`).
 
 ## Open questions / blockers
 
 - Whether to fold full per-PR preview deploys + the f311x Sentry slice into this
-  push or sequence them after Phases 3-4.
+  push or sequence them after Phase 4.
+- Several apps beyond the five analyzed (forzamonica.com, monicandavid.com,
+  onvibes.org, pkg.dog, revision.city, startchi.com) -- confirm which are
+  deployed and need a smoke gate too.

--- a/docs/projects/testing-harness/2026-06-14-progress.md
+++ b/docs/projects/testing-harness/2026-06-14-progress.md
@@ -1,0 +1,50 @@
+# 2026-06-14 -- Testing harness kickoff + Phase 0
+
+## Session summary
+
+Surveyed the monorepo's testing state to prioritize "good testing harnesses for
+code quality." Found the scaffolding already in place but the content and
+runtime layers thin, and -- more pressingly -- that a fresh web container could
+not build, test, or boot any app at all. Set up the web-session bootstrap
+(Phase 0) so the rest of the work is verifiable here, not just in CI.
+
+## Work completed
+
+- Mapped the testing landscape: all 11 apps have a Vitest config + `test` mise
+  task in CI; 7 are empty `passWithNoTests` placeholders; only djf.io has e2e
+  (Playwright); f311x has a sharp post-deploy smoke gate (`bin/smoke-test.ts`)
+  that runs in CD only.
+- **Phase 0 -- SessionStart hook** (`.claude/hooks/session-start.ts`, bun):
+  installs the mise toolchain (Node 26, pnpm 11, bun, biome, oxlint, prettier)
+  and every app's deps on a fresh web container. Registered in
+  `.claude/settings.json`. Sync mode.
+- Validated on Node 26 / pnpm 11: f311x deps install in ~17s; `biome check` on a
+  file is clean; `vitest run` on a file is 3/3 green.
+
+## Decisions made
+
+- **Hooks are bun, not bash** (per repo rule + David's call). The hook uses
+  `Bun.$`; the system bun already present in the container bootstraps it before
+  mise installs the pinned bun.
+- **Sync hook mode** for now: guarantees deps are ready before the session
+  starts (no race), at the cost of slower cold starts. Async is a one-line
+  switch if startup latency becomes annoying.
+- **Framing: a layered safety net** (unit -> smoke -> e2e -> coverage), with
+  this project owning the test-execution layers and the web-session bootstrap;
+  preview-deployments owns preview infra + visual regression; sentry-integration
+  owns diagnosis.
+- `.config/mise.lock` makes the toolchain install deterministic and dodges the
+  GitHub release-API rate limit unauthenticated containers hit.
+
+## Next steps
+
+- **Phase 1 spike**: confirm whether `vite preview` serves the f311x worker
+  (SSR + chat endpoint) locally, or whether the smoke boot needs `wrangler dev`.
+- Refactor `bin/smoke-test.ts` into a reusable checks module; add a
+  `mise run smoke` task (local boot) + a CI job on PRs.
+
+## Open questions / blockers
+
+- `vite preview` vs `wrangler dev` for the f311x local smoke boot (spike above).
+- Whether to fold full per-PR preview deploys + the f311x Sentry slice into this
+  push or sequence them after the local smoke pattern is proven.

--- a/docs/projects/testing-harness/plan.md
+++ b/docs/projects/testing-harness/plan.md
@@ -72,10 +72,17 @@ green (17 pages). calendar-visualizer's core (`getCalendarDisplayState`) was
 already well covered (11 tests); its only gap is the component-local
 `getDayVariant`, left as a low-value follow-up.
 
-### Phase 4 -- Repo-wide test + coverage gate
+### Phase 4 -- Repo-wide test + coverage gate (DONE 2026-06-14)
 
-A root aggregator to run all app tests, plus coverage thresholds, so quality
-cannot silently regress as code lands.
+Added a monorepo aggregator -- `bin/run-app-tasks.ts` (bun) behind root
+`mise run test` / `mise run check` -- that fans a task out to every app (with
+`CI=true`, dodging the pnpm purge papercut) and prints a pass/fail summary, so
+the whole repo verifies with one command (complementing the per-app,
+path-filtered CI). Added vitest v8 coverage gates scoped to the pure logic of
+the apps with real tests -- f311x (`src/lib/**`) and djf.io (`src/lib/**` +
+`content.config.ts`), both at 100%, with ratchet thresholds enforced via
+`--coverage` in their unit task. calendar-visualizer and forzamonica.com follow
+the same recipe (next).
 
 ## Open questions
 

--- a/docs/projects/testing-harness/plan.md
+++ b/docs/projects/testing-harness/plan.md
@@ -1,0 +1,78 @@
+# Testing Harness & Code-Quality Safety Net
+
+## Goal
+
+A layered, fast safety net so changes across the monorepo can be made and
+verified quickly and confidently -- unit -> smoke -> e2e -> coverage -- and so
+those checks actually run inside Claude Code on the web, not only in GitHub CI.
+
+## Rationale
+
+- The test *scaffolding* already exists (every app has a Vitest config and a
+  `test` mise task wired into CI), but 7 of 11 apps are empty `passWithNoTests`
+  placeholders and only djf.io has an e2e layer. The one runtime safety net
+  (f311x's smoke test) runs post-deploy only.
+- A fresh web container had neither the mise toolchain nor any app's
+  `node_modules`, so a web session could not run a single check or boot an app
+  -- every verification round-tripped through CI. That is the primary drag on
+  iteration speed.
+- f311x shipped green-CI-but-broken (2026-06-11); build-time checks cannot catch
+  runtime breakage. Pulling smoke checks earlier (pre-merge) is the fix.
+
+This project complements, rather than duplicates:
+
+- [preview-deployments](../preview-deployments/plan.md) -- owns the preview
+  *infrastructure* and visual regression. This project's smoke harness is built
+  URL-parameterized so the same task points at a local boot now and a preview
+  URL later.
+- [sentry-integration](../sentry-integration/plan.md) -- owns the *diagnosis*
+  half (why it broke). Smoke proves *that* it broke; Sentry says *why*.
+
+## Phases
+
+### Phase 0 -- Web-session bootstrap (DONE 2026-06-14)
+
+A `SessionStart` hook (`.claude/hooks/session-start.ts`, bun) installs the
+mise-pinned toolchain and every app's dependencies on a fresh web container, so
+mise tasks (typecheck / lint / format / test / build) and smoke boots work the
+same way they do in CI. Sync mode.
+
+### Phase 1 -- f311x smoke -> pre-merge
+
+Pull f311x's existing post-deploy smoke gate (`bin/smoke-test.ts`) into a
+canonical `mise run smoke` task that boots the app locally and runs the same
+checks, plus a CI job on PRs. Deterministic (echo stub, no secrets). Refactor
+the smoke checks into a reusable module so prod (CD) and local/preview (CI)
+share one implementation.
+
+### Phase 2 -- Generalize the e2e/smoke pattern
+
+Promote the f311x smoke and djf.io Playwright setups into one documented
+convention (the `smoke` task contract + a short testing guide), then roll it to
+the other deployed apps (djf.io, calendar-visualizer, davidjfelix.com, ravrun).
+
+### Phase 3 -- Backfill real unit tests
+
+Replace empty `passWithNoTests` placeholders with meaningful unit tests where
+logic exists (djf.io content config / SEO, calendar-visualizer state).
+
+### Phase 4 -- Repo-wide test + coverage gate
+
+A root aggregator to run all app tests, plus coverage thresholds, so quality
+cannot silently regress as code lands.
+
+## Open questions
+
+- Does `vite preview` serve the f311x worker (SSR + chat endpoint) locally, or
+  is `wrangler dev` needed for the smoke boot? (Phase 1 spike.)
+- Coverage tooling and thresholds (Phase 4).
+- Screenshot / visual-regression baseline strategy -- deferred to
+  preview-deployments.
+
+## Related
+
+- [preview-deployments](../preview-deployments/plan.md) -- preview infra; smoke
+  results feed its auto-merge gate
+- [sentry-integration](../sentry-integration/plan.md) -- the diagnosis half
+- [dependency-freshness](../dependency-freshness/plan.md) -- auto-merge bar
+  consumes smoke + preview verification

--- a/docs/projects/testing-harness/plan.md
+++ b/docs/projects/testing-harness/plan.md
@@ -37,13 +37,15 @@ mise-pinned toolchain and every app's dependencies on a fresh web container, so
 mise tasks (typecheck / lint / format / test / build) and smoke boots work the
 same way they do in CI. Sync mode.
 
-### Phase 1 -- f311x smoke -> pre-merge
+### Phase 1 -- f311x smoke -> pre-merge (DONE 2026-06-14)
 
-Pull f311x's existing post-deploy smoke gate (`bin/smoke-test.ts`) into a
-canonical `mise run smoke` task that boots the app locally and runs the same
-checks, plus a CI job on PRs. Deterministic (echo stub, no secrets). Refactor
-the smoke checks into a reusable module so prod (CD) and local/preview (CI)
-share one implementation.
+`bin/smoke-checks.ts` holds the shared checks; `bin/smoke-test.ts` (CD, prod
+URLs) and `bin/smoke-local.ts` (pre-merge) both use them. `mise run smoke`
+builds, boots the production server bundle under workerd via `wrangler dev`, and
+runs the gate against it -- high fidelity (the real Workers runtime) and
+deterministic (echo stub, no secrets). Wired as a CI job on PRs in
+ci-f311x.yml. The gate stays URL-parameterized (`SMOKE_URLS`), so it can later
+point at a per-PR preview deploy with no rework.
 
 ### Phase 2 -- Generalize the e2e/smoke pattern
 
@@ -63,8 +65,9 @@ cannot silently regress as code lands.
 
 ## Open questions
 
-- Does `vite preview` serve the f311x worker (SSR + chat endpoint) locally, or
-  is `wrangler dev` needed for the smoke boot? (Phase 1 spike.)
+- ~~Local boot for f311x smoke?~~ Resolved (Phase 1): `vite preview` is
+  static-only and the built `dist/server/server.js` is a Worker `fetch` module,
+  so the boot is `wrangler dev` on the built worker (workerd).
 - Coverage tooling and thresholds (Phase 4).
 - Screenshot / visual-regression baseline strategy -- deferred to
   preview-deployments.

--- a/docs/projects/testing-harness/plan.md
+++ b/docs/projects/testing-harness/plan.md
@@ -59,10 +59,18 @@ duplicate smoke task. Apps that run bun scripts but lacked `@types/bun` got it
 added, with a `/// <reference types="bun" />` in the script (the reliable
 cross-tsconfig way to pull the global in).
 
-### Phase 3 -- Backfill real unit tests
+### Phase 3 -- Backfill real unit tests (DONE 2026-06-14)
 
-Replace empty `passWithNoTests` placeholders with meaningful unit tests where
-logic exists (djf.io content config / SEO, calendar-visualizer state).
+djf.io's blog list / tag logic -- date sort, tag collection, tag counts, tag
+filtering, date formatting -- was duplicated inline across rss.xml, blog/index,
+blog/tags/* and the BlogPost layout. Extracted it into a pure, structurally
+typed `src/lib/blog.ts`, refactored all five call sites to use it, and covered
+it with `src/lib/blog.test.ts` (11 tests). The extracted code is the code that
+runs, so the tests guard real regressions (feed / index / tag ordering, tag-page
+popularity, date display). djf.io now has 44 passing unit tests; build still
+green (17 pages). calendar-visualizer's core (`getCalendarDisplayState`) was
+already well covered (11 tests); its only gap is the component-local
+`getDayVariant`, left as a low-value follow-up.
 
 ### Phase 4 -- Repo-wide test + coverage gate
 
@@ -77,6 +85,11 @@ cannot silently regress as code lands.
 - Coverage tooling and thresholds (Phase 4).
 - Screenshot / visual-regression baseline strategy -- deferred to
   preview-deployments.
+- pnpm `verify-deps-before-run` aborts (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`)
+  when a task runs with no TTY and `node_modules` has drifted, so `mise run <task>`
+  fails in a web session unless `CI=true` is set (CI and the SessionStart hook set
+  it; manual runs do not). Durable fix candidates: a root `.npmrc`
+  `confirm-modules-purge=false`, or pinning the `latest`-tagged dev deps that drift.
 
 ## Related
 

--- a/docs/projects/testing-harness/plan.md
+++ b/docs/projects/testing-harness/plan.md
@@ -81,8 +81,9 @@ the whole repo verifies with one command (complementing the per-app,
 path-filtered CI). Added vitest v8 coverage gates scoped to the pure logic of
 the apps with real tests -- f311x (`src/lib/**`) and djf.io (`src/lib/**` +
 `content.config.ts`), both at 100%, with ratchet thresholds enforced via
-`--coverage` in their unit task. calendar-visualizer and forzamonica.com follow
-the same recipe (next).
+`--coverage` in their unit task. The same gate now also covers calendar-visualizer
+(`src/components/calendar-state.ts`) and forzamonica.com
+(`src/lib/format-price.ts`) -- every app with real unit tests is gated.
 
 ## Open questions
 

--- a/docs/projects/testing-harness/plan.md
+++ b/docs/projects/testing-harness/plan.md
@@ -47,11 +47,17 @@ deterministic (echo stub, no secrets). Wired as a CI job on PRs in
 ci-f311x.yml. The gate stays URL-parameterized (`SMOKE_URLS`), so it can later
 point at a per-PR preview deploy with no rework.
 
-### Phase 2 -- Generalize the e2e/smoke pattern
+### Phase 2 -- Generalize the smoke pattern (DONE 2026-06-14)
 
-Promote the f311x smoke and djf.io Playwright setups into one documented
-convention (the `smoke` task contract + a short testing guide), then roll it to
-the other deployed apps (djf.io, calendar-visualizer, davidjfelix.com, ravrun).
+Documented the `smoke` task contract in CLAUDE.md (Testing Conventions ->
+Runtime checks) and rolled it to the deployed apps that lacked a runtime gate:
+calendar-visualizer and davidjfelix.com (static Astro -> `astro preview`) and
+ravrun (Vite SPA -> `vite preview`). Each gets a `bin/smoke-local.ts`, a `smoke`
+mise task (depends on `build`), and a `smoke` CI job. djf.io already has a
+Playwright e2e suite as its runtime gate, so it keeps that instead of a
+duplicate smoke task. Apps that run bun scripts but lacked `@types/bun` got it
+added, with a `/// <reference types="bun" />` in the script (the reliable
+cross-tsconfig way to pull the global in).
 
 ### Phase 3 -- Backfill real unit tests
 


### PR DESCRIPTION
Builds out the monorepo testing harness: a runtime gate for every deployed app, real unit tests with coverage ratchets, and one-command verification — runnable both in Claude Code web sessions and CI.

## What's here

**Web-session bootstrap** (`2cf5dea`)
- A `SessionStart` hook installs the toolchain + per-app deps so checks and tests actually run in web sessions.

**Smoke gates — every deployed app** (`224982e`, `6c0abaf`, `42ea194`)
- A `smoke` mise task per deployed app: boots the *production build* locally and asserts the critical path serves — each key route returns 200 as a complete HTML document whose hashed client assets also serve.
- Boot per stack: static Astro → `astro preview`; Vite SPA → `vite preview`; Cloudflare Worker → `wrangler dev` on the built worker (f311x also POSTs its chat endpoint and requires the echo stream); forzamonica.com is a TanStack Start worker served via `@cloudflare/vite-plugin`'s `vite preview`.
- Wired into CI as a `smoke` job per app. djf.io keeps its Playwright e2e as its (superset) runtime gate.
- Coverage: f311x, calendar-visualizer, davidjfelix.com, ravrun, forzamonica.com (+ djf.io via e2e) — every deployed app now has a runtime gate.

**Unit tests + coverage gates** (`11aa03c`, `2d2bbca`, `447699b`)
- Extracted djf.io's blog list/tag logic (date sort, tag collect/count/filter, date format) — previously duplicated across feed/index/tag pages — into a pure, tested `src/lib/blog.ts`.
- v8 coverage gates scoped to each app's pure logic, with ratchet thresholds enforced via `vitest run --coverage`: f311x (`src/lib/**`), djf.io (`src/lib/**` + content config), calendar-visualizer (`calendar-state.ts`), forzamonica.com (`format-price.ts`) — every app with real unit tests is gated.

**Monorepo aggregator** (`2d2bbca`)
- `bin/run-app-tasks.ts` behind root `mise run test` / `mise run check` fans a task across every app (with `CI=true`) for one-command whole-repo verification, complementing the per-app, path-filtered CI.

## Validation
Every affected app passes typecheck / lint / format / test (+coverage) / smoke locally; workflow changes pass actionlint. See `docs/projects/testing-harness/plan.md` for the full plan and progress notes.

https://claude.ai/code/session_01S6VqZ5wogg6FE8f4U6oJhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6VqZ5wogg6FE8f4U6oJhb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds CI smoke jobs that boot production builds (ports, timing, worker runtime) and changes test/coverage enforcement; low prod runtime risk but can increase PR CI time and flake surface.
> 
> **Overview**
> Introduces a **layered testing harness** so runtime breakage is caught before merge and the whole monorepo can be verified locally or in Claude Code web sessions—not only in path-filtered CI.
> 
> **Claude Code web bootstrap:** A `SessionStart` hook (`.claude/hooks/session-start.ts`) installs mise + per-app `pnpm install` when `CLAUDE_CODE_REMOTE=true`, with `CI=true` to avoid non-TTY pnpm aborts.
> 
> **Smoke (`mise run smoke`):** New `bin/smoke-local.ts` per deployed app, stack-specific boots (`astro preview`, `vite preview`, or `wrangler dev` for f311x), and matching **`smoke` CI jobs** in five app workflows. f311x shares checks via `bin/smoke-checks.ts`; post-deploy `smoke-test.ts` delegates to the same module. djf.io keeps Playwright e2e as its runtime gate.
> 
> **Unit tests & coverage:** djf.io blog sort/tag/date logic moves to `src/lib/blog.ts` with tests; Vitest v8 `--coverage` and scoped thresholds land on f311x, djf.io, calendar-visualizer, and forzamonica.com.
> 
> **Monorepo commands:** Root `mise run test` / `check` call `bin/run-app-tasks.ts` across all apps. `CLAUDE.md` and `docs/projects/testing-harness/` document the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5899f630910661b15bbd97b08ea5fa7200c5b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->