### PR TITLE
test(apps): add runtime smoke gates for five deployed sites

### DIFF
--- a/.github/workflows/ci-monicandavid-com.yml
+++ b/.github/workflows/ci-monicandavid-com.yml
@@ -133,3 +133,24 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: ./.github/actions/setup-mise
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/.github/workflows/ci-onvibes-org.yml
+++ b/.github/workflows/ci-onvibes-org.yml
@@ -133,3 +133,24 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: ./.github/actions/setup-mise
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/.github/workflows/ci-pkg-dog.yml
+++ b/.github/workflows/ci-pkg-dog.yml
@@ -133,3 +133,24 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: ./.github/actions/setup-mise
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/.github/workflows/ci-revision-city.yml
+++ b/.github/workflows/ci-revision-city.yml
@@ -133,3 +133,24 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: ./.github/actions/setup-mise
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/.github/workflows/ci-startchi-com.yml
+++ b/.github/workflows/ci-startchi-com.yml
@@ -133,3 +133,24 @@ jobs:
 
       - name: vitest
         run: mise run test
+
+  smoke:
+    name: smoke (local production boot)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: mise
+        uses: ./.github/actions/setup-mise
+
+      - name: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: smoke
+        run: mise run smoke

--- a/apps/monicandavid.com/bin/smoke-local.ts
+++ b/apps/monicandavid.com/bin/smoke-local.ts
@@ -1,0 +1,94 @@
+/// <reference types="bun" />
+// Pre-merge smoke gate: boots the *built* worker locally under workerd (via
+// `wrangler dev`) and checks the critical path serves a working bundle -- the
+// route returns 200, the response is a complete HTML document, and any hashed
+// client asset it references itself serves. Catches the "deployed but broken"
+// class before merge, not after.
+//
+// Why wrangler dev and not `vite preview`: monicandavid.com is SvelteKit on
+// Cloudflare (adapter-cloudflare). SvelteKit's `vite preview` runs the SSR app
+// under *Node*, not workerd -- it would pass while smoking the wrong runtime.
+// Booting the adapter's _worker.js under wrangler exercises the artifact that
+// actually ships. The worker entry, assets dir, and compatibility settings are
+// all read from wrangler.toml (config-driven dev), so the local runtime matches
+// the deployed one. Assumes `vite build` has run (the `smoke` task depends on
+// `build`); parameterized via SMOKE_ROUTES / SMOKE_PORT.
+
+import {existsSync} from 'node:fs'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4317)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const ROUTES = (process.env.SMOKE_ROUTES ?? '/').split(',')
+const WORKER = '.svelte-kit/cloudflare/_worker.js'
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync(WORKER)) {
+  console.error(`::error::${WORKER} is missing -- run \`mise run build\` first`)
+  process.exit(1)
+}
+
+// Spawn the wrangler binary directly (not via `pnpm exec`): killing the pnpm
+// wrapper does not cascade to wrangler/workerd, which would then outlive
+// teardown and keep holding the port. Worker entry, --assets, and compatibility
+// settings come from wrangler.toml, so this matches the deploy exactly.
+const worker = Bun.spawn(
+  ['node_modules/.bin/wrangler', 'dev', '--port', String(PORT), '--ip', '127.0.0.1'],
+  {
+    env: {...process.env, CI: 'true', WRANGLER_SEND_METRICS: 'false'},
+    stdout: 'ignore',
+    stderr: 'inherit',
+  },
+)
+
+async function check(route: string): Promise<string | null> {
+  const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `${route} -> HTTP ${page.status}`
+  const html = await page.text()
+  if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
+  if (asset) {
+    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
+  }
+  return null
+}
+
+async function waitForReady(): Promise<boolean> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) return true
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+  return false
+}
+
+let exitCode = 0
+try {
+  if (!(await waitForReady())) {
+    console.error(
+      `::error::worker did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    for (const route of ROUTES) {
+      const problem = await check(route)
+      if (problem === null) {
+        console.log(`OK: ${route} serves a working bundle`)
+      } else {
+        console.error(`::error::smoke test failed — ${problem}`)
+        exitCode = 1
+      }
+    }
+  }
+} finally {
+  worker.kill()
+  await Promise.race([worker.exited, Bun.sleep(3_000)])
+  worker.kill('SIGKILL')
+}
+
+process.exit(exitCode)

--- a/apps/monicandavid.com/mise.toml
+++ b/apps/monicandavid.com/mise.toml
@@ -25,6 +25,11 @@ run = "pnpm run test"
 description = "Build with Vite"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (workerd via wrangler dev)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/onvibes.org/bin/smoke-local.ts
+++ b/apps/onvibes.org/bin/smoke-local.ts
@@ -1,0 +1,85 @@
+/// <reference types="bun" />
+// Pre-merge smoke gate: boots the production preview server and checks the
+// critical path serves a working bundle -- the route returns 200, the response
+// is a complete HTML document, and any hashed client asset it references itself
+// serves. Catches the "deployed but broken" class (route 404/500, missing
+// assets) before merge. Deterministic and secret-free.
+//
+// onvibes.org is a static Astro site (no SSR adapter); `astro preview` serves
+// the built `dist/` exactly as Cloudflare serves it. Assumes `astro build` has
+// run (the `smoke` mise task depends on `build`). Parameterized via
+// SMOKE_ROUTES / SMOKE_PORT so the same checks can later target a preview deploy.
+
+import {existsSync} from 'node:fs'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4321)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const ROUTES = (process.env.SMOKE_ROUTES ?? '/').split(',')
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync('dist')) {
+  console.error('::error::dist is missing -- run `mise run build` first')
+  process.exit(1)
+}
+
+// Spawn the preview binary directly (not through `pnpm run`): killing the pnpm
+// wrapper does not cascade to the server, so it would outlive teardown and hold
+// the port. Detached stdio keeps the server from holding this process's pipes
+// open, which would otherwise stall a `... | tail` pipeline after we exit.
+const server = Bun.spawn(
+  ['node_modules/.bin/astro', 'preview', '--host', '127.0.0.1', '--port', String(PORT)],
+  {env: {...process.env, CI: 'true'}, stdout: 'ignore', stderr: 'ignore'},
+)
+
+async function check(route: string): Promise<string | null> {
+  const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `${route} -> HTTP ${page.status}`
+  const html = await page.text()
+  if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
+  if (asset) {
+    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
+  }
+  return null
+}
+
+async function waitForReady(): Promise<boolean> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) return true
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+  return false
+}
+
+let exitCode = 0
+try {
+  if (!(await waitForReady())) {
+    console.error(
+      `::error::preview did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    for (const route of ROUTES) {
+      const problem = await check(route)
+      if (problem === null) {
+        console.log(`OK: ${route} serves a working bundle`)
+      } else {
+        console.error(`::error::smoke test failed — ${problem}`)
+        exitCode = 1
+      }
+    }
+  }
+} finally {
+  server.kill()
+  await Promise.race([server.exited, Bun.sleep(3_000)])
+  server.kill('SIGKILL')
+}
+
+process.exit(exitCode)

--- a/apps/onvibes.org/mise.toml
+++ b/apps/onvibes.org/mise.toml
@@ -28,6 +28,11 @@ run = "pnpm run test"
 description = "Build with Astro"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (astro preview)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/pkg.dog/bin/smoke-local.ts
+++ b/apps/pkg.dog/bin/smoke-local.ts
@@ -1,0 +1,95 @@
+/// <reference types="bun" />
+// Pre-merge smoke gate: boots the *built* worker locally under workerd (via
+// `wrangler dev`) and checks the critical path serves a working bundle -- the
+// route returns 200, the response is a complete HTML document, and any hashed
+// client asset it references itself serves. Catches the "deployed but broken"
+// class before merge, not after.
+//
+// Why wrangler dev directly and not `nuxt preview`: pkg.dog is Nuxt on
+// Cloudflare (Nitro cloudflare_module). `nuxt preview` does boot workerd, but
+// only by shelling out to `wrangler dev` as a wrapped child process -- which
+// breaks the "kill cascades, port released" rule, leaving workerd holding the port past
+// teardown. Spawning wrangler directly avoids the trap. The worker entry, assets
+// dir, and compatibility settings are read from wrangler.toml (config-driven
+// dev), so the local runtime matches the deployed one. Assumes `nuxt build` has
+// run (the `smoke` task depends on `build`); parameterized via SMOKE_ROUTES /
+// SMOKE_PORT.
+
+import {existsSync} from 'node:fs'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4318)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const ROUTES = (process.env.SMOKE_ROUTES ?? '/').split(',')
+const WORKER = '.output/server/index.mjs'
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync(WORKER)) {
+  console.error(`::error::${WORKER} is missing -- run \`mise run build\` first`)
+  process.exit(1)
+}
+
+// Spawn the wrangler binary directly (not via `pnpm exec`): killing the pnpm
+// wrapper does not cascade to wrangler/workerd, which would then outlive
+// teardown and keep holding the port. Worker entry, --assets, and compatibility
+// settings come from wrangler.toml, so this matches the deploy exactly.
+const worker = Bun.spawn(
+  ['node_modules/.bin/wrangler', 'dev', '--port', String(PORT), '--ip', '127.0.0.1'],
+  {
+    env: {...process.env, CI: 'true', WRANGLER_SEND_METRICS: 'false'},
+    stdout: 'ignore',
+    stderr: 'inherit',
+  },
+)
+
+async function check(route: string): Promise<string | null> {
+  const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `${route} -> HTTP ${page.status}`
+  const html = await page.text()
+  if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
+  if (asset) {
+    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
+  }
+  return null
+}
+
+async function waitForReady(): Promise<boolean> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) return true
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+  return false
+}
+
+let exitCode = 0
+try {
+  if (!(await waitForReady())) {
+    console.error(
+      `::error::worker did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    for (const route of ROUTES) {
+      const problem = await check(route)
+      if (problem === null) {
+        console.log(`OK: ${route} serves a working bundle`)
+      } else {
+        console.error(`::error::smoke test failed — ${problem}`)
+        exitCode = 1
+      }
+    }
+  }
+} finally {
+  worker.kill()
+  await Promise.race([worker.exited, Bun.sleep(3_000)])
+  worker.kill('SIGKILL')
+}
+
+process.exit(exitCode)

--- a/apps/pkg.dog/mise.toml
+++ b/apps/pkg.dog/mise.toml
@@ -25,6 +25,11 @@ run = "pnpm run test"
 description = "Build with Nuxt"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (workerd via wrangler dev)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/revision.city/bin/smoke-local.ts
+++ b/apps/revision.city/bin/smoke-local.ts
@@ -1,0 +1,85 @@
+/// <reference types="bun" />
+// Pre-merge smoke gate: boots the production build and checks the critical path
+// serves a working bundle -- the route returns 200, the response is a complete
+// HTML document, and any hashed client asset it references itself serves.
+//
+// revision.city is a TanStack Start app on Cloudflare Workers; its
+// @cloudflare/vite-plugin makes `vite preview` serve the built worker (SSR) in
+// workerd, so `/` exercises the real render path. A dev-mode bundle would
+// reference a virtual dev entry that 404s here -- exactly the "deployed but
+// broken" class this catches before merge. Assumes `vite build` has run (the
+// `smoke` task depends on `build`); parameterized via SMOKE_ROUTES / SMOKE_PORT.
+
+import {existsSync} from 'node:fs'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4173)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const ROUTES = (process.env.SMOKE_ROUTES ?? '/').split(',')
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync('dist')) {
+  console.error('::error::dist is missing -- run `mise run build` first')
+  process.exit(1)
+}
+
+// Spawn the preview binary directly (not through `pnpm run`): killing the pnpm
+// wrapper does not cascade to the server, so it would outlive teardown and hold
+// the port. Detached stdio keeps the server from holding this process's pipes
+// open, which would otherwise stall a `... | tail` pipeline after we exit.
+const server = Bun.spawn(
+  ['node_modules/.bin/vite', 'preview', '--host', '127.0.0.1', '--port', String(PORT)],
+  {env: {...process.env, CI: 'true'}, stdout: 'ignore', stderr: 'ignore'},
+)
+
+async function check(route: string): Promise<string | null> {
+  const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `${route} -> HTTP ${page.status}`
+  const html = await page.text()
+  if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
+  if (asset) {
+    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
+  }
+  return null
+}
+
+async function waitForReady(): Promise<boolean> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) return true
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+  return false
+}
+
+let exitCode = 0
+try {
+  if (!(await waitForReady())) {
+    console.error(
+      `::error::preview did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    for (const route of ROUTES) {
+      const problem = await check(route)
+      if (problem === null) {
+        console.log(`OK: ${route} serves a working bundle`)
+      } else {
+        console.error(`::error::smoke test failed — ${problem}`)
+        exitCode = 1
+      }
+    }
+  }
+} finally {
+  server.kill()
+  await Promise.race([server.exited, Bun.sleep(3_000)])
+  server.kill('SIGKILL')
+}
+
+process.exit(exitCode)

--- a/apps/revision.city/bin/smoke-local.ts
+++ b/apps/revision.city/bin/smoke-local.ts
@@ -31,16 +31,22 @@ const server = Bun.spawn(
   {env: {...process.env, CI: 'true'}, stdout: 'ignore', stderr: 'ignore'},
 )
 
+// A dev-mode bundle references this Vite/TanStack dev virtual entry (the 2026-06-11 f311x
+// incident); reject it, and require a real hashed asset -- a dev bundle references no hashed
+// `.js`/`.css`, so without this the check would pass vacuously.
+const DEV_ENTRY = 'virtual:tanstack-start-dev-client-entry'
+
 async function check(route: string): Promise<string | null> {
   const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
   if (!page.ok) return `${route} -> HTTP ${page.status}`
   const html = await page.text()
   if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  if (html.includes(DEV_ENTRY))
+    return `${route} -> serves a dev-mode bundle (dev virtual entry present)`
   const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
-  if (asset) {
-    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
-    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
-  }
+  if (!asset) return `${route} -> no hashed client asset referenced in HTML`
+  const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
   return null
 }
 

--- a/apps/revision.city/mise.toml
+++ b/apps/revision.city/mise.toml
@@ -25,6 +25,11 @@ run = "pnpm run test"
 description = "Build with Vite"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (vite preview on workerd)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/revision.city/package.json
+++ b/apps/revision.city/package.json
@@ -33,6 +33,7 @@
     "@cloudflare/workers-types": "4.20260613.1",
     "@pandacss/dev": "1.11.3",
     "@tanstack/devtools-vite": "latest",
+    "@types/bun": "1.3.14",
     "@types/node": "25.9.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/apps/revision.city/pnpm-lock.yaml
+++ b/apps/revision.city/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@tanstack/devtools-vite':
         specifier: latest
         version: 0.7.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/node':
         specifier: 25.9.3
         version: 25.9.3
@@ -53,7 +56,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@typescript/native-preview':
         specifier: latest
-        version: 7.0.0-dev.20260614.1
+        version: 7.0.0-dev.20260616.1
       '@vitejs/plugin-react':
         specifier: 6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
@@ -1416,6 +1419,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1439,50 +1445,50 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-2JHbdJ00FKTKDR1+NL4zhQBDlFZfZHEXaAarV6kbEjV0P47qKnSrAzzKHuponG0B9FqkPEMHOgu7WGJTBW2rHw==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-9SwegwwE7fYutnZJjTi2PeUXhKGFg82MGjSpCFD2cj5v9YQcs5oO5QsmeeMit4fMG8Z83Jy8knOF97d9NaQ7Bg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-/8enyEb1tDsVvUp4rDeA5DernrvWgD6cQ4rY6O6PH6BQK8fqwY+CcHEHmw2xgwfqoswHNYjznLvmQmHBOjHqLw==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-gl7R8OiwEBNxzs5wjbM9XOibTs5b6/gAgu0+En9pLpYuWR/EITs8Eh0mNQui4JYTp1SkoHvn09aRZKTQf21XTg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-jqhqAXqyEUxJpno/wRfWGa72R3VTt7p2LRTOFJ0C1bx5dEKrVosQSOdr2m9+2VhjXFXNvorXsGZPIWqxLOo28Q==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-CJjplWoE+EeYtbyNeP4fyuh0QcPiQBZJSLqPS07E3ugo3d9M/IG8WnL+3GFQ0g1p4c6QC/+OC0oTTQnGcNdd2Q==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-zYrUKq5oC6fUoHpOmT3B65hFMhbdIlLp7T9RW1/6a+wSYoq9xTRAeFufQ2XZ9cpTJ1tfIvlUmtgJJ5CGE/cOrg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-QWXQS2CrhSpXbng7vBtCVDszFgwVBuJU8MCFhxZL0hH6s+XjQDSNNkGO1oHueBr+7HbSkkyqfNYVNXvgVMUJLQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-K2c/DN7Q3a6Z+KIl7bq45xByuuGjacqWO/UPCa/iTBA/m6GDzoMJ/Q/DBLtLRHyROBRiy5kjgEZfyLy3Tp8ygw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-UVySBNnGTAnul2kO2/EhlVZl0CeTDcd6Lzi+WkvgyCgapTcU0BX1selQ4MEPtbVWKUbt9HBhxNku2dyaCcmKVw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-C+C25Grr4sCbQIYPT5WfKYIL613ZIN9aGcUwDGMSTmIQ3azIR5MtdkSF4l4vsOC4lF8HwFV83MDa28JuQYhQFg==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-kdX0QcDXiESH0o5DFdSWw15Hth0EtQobT9tX28ofqBUwGU1FFhwTKzA6qo7chaYUSW5MMd6XIME9rBwk+WizLw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-nJBR61NGiCMBJOpdzJ4ZgA/HEd+fqIb99ur39UljSH9xvFKFlRwDosyAQFD8UEwrZsUbXN0VPLJY5MDknug3GA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-EB0Pj/0+nXifS3+wN0HdR1mKu7IieSpjMXoDjdXtJAdiPGlmKazBgHj97qn6CBvXisgLx0Eyb7tLCEQNDG53cA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-4N1ZBHJUcsjKJQnUCxKUemV3jnm0PKZIZ4xh7dXN/3/AfmckE8Z1llyqOFfDwGOf8oQpdgkwQ6JUm7pqI3bGPg==}
+  '@typescript/native-preview@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-+AuZUl7nkLPXL1rwsyZZF7iasu0HkrL5O6aWwUC0cObD5EvNgxz3hXbBhsSvuJ8tb2JRpVwFsE0BHPcYVe5GkA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -1858,6 +1864,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -4534,6 +4543,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -4557,36 +4570,36 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
+  '@typescript/native-preview@7.0.0-dev.20260616.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260614.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260616.1
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))':
     dependencies:
@@ -5321,6 +5334,10 @@ snapshots:
       electron-to-chromium: 1.5.372
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.9.3
 
   bytes@3.1.2: {}
 

--- a/apps/startchi.com/bin/smoke-local.ts
+++ b/apps/startchi.com/bin/smoke-local.ts
@@ -31,16 +31,22 @@ const server = Bun.spawn(
   {env: {...process.env, CI: 'true'}, stdout: 'ignore', stderr: 'ignore'},
 )
 
+// A dev-mode bundle references this Vite/TanStack dev virtual entry (the 2026-06-11 f311x
+// incident); reject it, and require a real hashed asset -- a dev bundle references no hashed
+// `.js`/`.css`, so without this the check would pass vacuously.
+const DEV_ENTRY = 'virtual:tanstack-start-dev-client-entry'
+
 async function check(route: string): Promise<string | null> {
   const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
   if (!page.ok) return `${route} -> HTTP ${page.status}`
   const html = await page.text()
   if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  if (html.includes(DEV_ENTRY))
+    return `${route} -> serves a dev-mode bundle (dev virtual entry present)`
   const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
-  if (asset) {
-    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
-    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
-  }
+  if (!asset) return `${route} -> no hashed client asset referenced in HTML`
+  const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
   return null
 }
 

--- a/apps/startchi.com/bin/smoke-local.ts
+++ b/apps/startchi.com/bin/smoke-local.ts
@@ -1,0 +1,85 @@
+/// <reference types="bun" />
+// Pre-merge smoke gate: boots the production build and checks the critical path
+// serves a working bundle -- the route returns 200, the response is a complete
+// HTML document, and any hashed client asset it references itself serves.
+//
+// startchi.com is a TanStack Start app on Cloudflare Workers; its
+// @cloudflare/vite-plugin makes `vite preview` serve the built worker (SSR) in
+// workerd, so `/` exercises the real render path. A dev-mode bundle would
+// reference a virtual dev entry that 404s here -- exactly the "deployed but
+// broken" class this catches before merge. Assumes `vite build` has run (the
+// `smoke` task depends on `build`); parameterized via SMOKE_ROUTES / SMOKE_PORT.
+
+import {existsSync} from 'node:fs'
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4174)
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const ROUTES = (process.env.SMOKE_ROUTES ?? '/').split(',')
+const READY_TIMEOUT_MS = 60_000
+
+if (!existsSync('dist')) {
+  console.error('::error::dist is missing -- run `mise run build` first')
+  process.exit(1)
+}
+
+// Spawn the preview binary directly (not through `pnpm run`): killing the pnpm
+// wrapper does not cascade to the server, so it would outlive teardown and hold
+// the port. Detached stdio keeps the server from holding this process's pipes
+// open, which would otherwise stall a `... | tail` pipeline after we exit.
+const server = Bun.spawn(
+  ['node_modules/.bin/vite', 'preview', '--host', '127.0.0.1', '--port', String(PORT)],
+  {env: {...process.env, CI: 'true'}, stdout: 'ignore', stderr: 'ignore'},
+)
+
+async function check(route: string): Promise<string | null> {
+  const page = await fetch(new URL(route, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+  if (!page.ok) return `${route} -> HTTP ${page.status}`
+  const html = await page.text()
+  if (!/<\/html>/i.test(html)) return `${route} -> response is not a complete HTML document`
+  const asset = html.match(/(?:src|href)="(\/[^"]+\.(?:js|css))"/)?.[1]
+  if (asset) {
+    const res = await fetch(new URL(asset, BASE_URL), {signal: AbortSignal.timeout(15_000)})
+    if (!res.ok) return `${route} asset ${asset} -> HTTP ${res.status}`
+  }
+  return null
+}
+
+async function waitForReady(): Promise<boolean> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, {signal: AbortSignal.timeout(2_000)})
+      if (res.ok) return true
+    } catch {
+      // not up yet -- keep polling
+    }
+    await Bun.sleep(500)
+  }
+  return false
+}
+
+let exitCode = 0
+try {
+  if (!(await waitForReady())) {
+    console.error(
+      `::error::preview did not become ready on ${BASE_URL} within ${READY_TIMEOUT_MS}ms`,
+    )
+    exitCode = 1
+  } else {
+    for (const route of ROUTES) {
+      const problem = await check(route)
+      if (problem === null) {
+        console.log(`OK: ${route} serves a working bundle`)
+      } else {
+        console.error(`::error::smoke test failed — ${problem}`)
+        exitCode = 1
+      }
+    }
+  }
+} finally {
+  server.kill()
+  await Promise.race([server.exited, Bun.sleep(3_000)])
+  server.kill('SIGKILL')
+}
+
+process.exit(exitCode)

--- a/apps/startchi.com/mise.toml
+++ b/apps/startchi.com/mise.toml
@@ -25,6 +25,11 @@ run = "pnpm run test"
 description = "Build with Vite"
 run = "pnpm run build"
 
+[tasks.smoke]
+description = "Smoke-test a local production boot (vite preview on workerd)"
+depends = ["build"]
+run = "bun bin/smoke-local.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = ["typecheck", "lint", "format", "test", "build"]

--- a/apps/startchi.com/package.json
+++ b/apps/startchi.com/package.json
@@ -33,6 +33,7 @@
     "@cloudflare/workers-types": "4.20260613.1",
     "@pandacss/dev": "1.11.3",
     "@tanstack/devtools-vite": "latest",
+    "@types/bun": "1.3.14",
     "@types/node": "25.9.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/apps/startchi.com/pnpm-lock.yaml
+++ b/apps/startchi.com/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@tanstack/devtools-vite':
         specifier: latest
         version: 0.7.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/node':
         specifier: 25.9.3
         version: 25.9.3
@@ -53,7 +56,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@typescript/native-preview':
         specifier: latest
-        version: 7.0.0-dev.20260614.1
+        version: 7.0.0-dev.20260616.1
       '@vitejs/plugin-react':
         specifier: 6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))
@@ -1416,6 +1419,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1439,50 +1445,50 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-2JHbdJ00FKTKDR1+NL4zhQBDlFZfZHEXaAarV6kbEjV0P47qKnSrAzzKHuponG0B9FqkPEMHOgu7WGJTBW2rHw==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-9SwegwwE7fYutnZJjTi2PeUXhKGFg82MGjSpCFD2cj5v9YQcs5oO5QsmeeMit4fMG8Z83Jy8knOF97d9NaQ7Bg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-/8enyEb1tDsVvUp4rDeA5DernrvWgD6cQ4rY6O6PH6BQK8fqwY+CcHEHmw2xgwfqoswHNYjznLvmQmHBOjHqLw==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-gl7R8OiwEBNxzs5wjbM9XOibTs5b6/gAgu0+En9pLpYuWR/EITs8Eh0mNQui4JYTp1SkoHvn09aRZKTQf21XTg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-jqhqAXqyEUxJpno/wRfWGa72R3VTt7p2LRTOFJ0C1bx5dEKrVosQSOdr2m9+2VhjXFXNvorXsGZPIWqxLOo28Q==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-CJjplWoE+EeYtbyNeP4fyuh0QcPiQBZJSLqPS07E3ugo3d9M/IG8WnL+3GFQ0g1p4c6QC/+OC0oTTQnGcNdd2Q==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-zYrUKq5oC6fUoHpOmT3B65hFMhbdIlLp7T9RW1/6a+wSYoq9xTRAeFufQ2XZ9cpTJ1tfIvlUmtgJJ5CGE/cOrg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-QWXQS2CrhSpXbng7vBtCVDszFgwVBuJU8MCFhxZL0hH6s+XjQDSNNkGO1oHueBr+7HbSkkyqfNYVNXvgVMUJLQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-K2c/DN7Q3a6Z+KIl7bq45xByuuGjacqWO/UPCa/iTBA/m6GDzoMJ/Q/DBLtLRHyROBRiy5kjgEZfyLy3Tp8ygw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-UVySBNnGTAnul2kO2/EhlVZl0CeTDcd6Lzi+WkvgyCgapTcU0BX1selQ4MEPtbVWKUbt9HBhxNku2dyaCcmKVw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-C+C25Grr4sCbQIYPT5WfKYIL613ZIN9aGcUwDGMSTmIQ3azIR5MtdkSF4l4vsOC4lF8HwFV83MDa28JuQYhQFg==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-kdX0QcDXiESH0o5DFdSWw15Hth0EtQobT9tX28ofqBUwGU1FFhwTKzA6qo7chaYUSW5MMd6XIME9rBwk+WizLw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-nJBR61NGiCMBJOpdzJ4ZgA/HEd+fqIb99ur39UljSH9xvFKFlRwDosyAQFD8UEwrZsUbXN0VPLJY5MDknug3GA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-EB0Pj/0+nXifS3+wN0HdR1mKu7IieSpjMXoDjdXtJAdiPGlmKazBgHj97qn6CBvXisgLx0Eyb7tLCEQNDG53cA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
-    resolution: {integrity: sha512-4N1ZBHJUcsjKJQnUCxKUemV3jnm0PKZIZ4xh7dXN/3/AfmckE8Z1llyqOFfDwGOf8oQpdgkwQ6JUm7pqI3bGPg==}
+  '@typescript/native-preview@7.0.0-dev.20260616.1':
+    resolution: {integrity: sha512-+AuZUl7nkLPXL1rwsyZZF7iasu0HkrL5O6aWwUC0cObD5EvNgxz3hXbBhsSvuJ8tb2JRpVwFsE0BHPcYVe5GkA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -1858,6 +1864,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -4534,6 +4543,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -4557,36 +4570,36 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260614.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260616.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260614.1':
+  '@typescript/native-preview@7.0.0-dev.20260616.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260614.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260614.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260616.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260616.1
 
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.3)(jiti@2.7.0))':
     dependencies:
@@ -5321,6 +5334,10 @@ snapshots:
       electron-to-chromium: 1.5.372
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.9.3
 
   bytes@3.1.2: {}
 

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -21,6 +21,24 @@ template default with no recorded rationale) now use the shared cache too — sa
 the key is lockfile-scoped (identical pinned tool binaries) and deploys run only on
 `push: main`, a trusted context whose cache scope no untrusted PR can write to.
 
+### test(apps): runtime smoke gates for the five deployed scaffolded sites
+
+The five scaffolded sites (onvibes.org, revision.city, startchi.com, monicandavid.com,
+pkg.dog) had shipped to Cloudflare since 2026-06-14 with no runtime gate — a violation of
+the CLAUDE.md contract that every deployed app boot its production build locally and assert
+the critical path serves, and exactly the "green CI, broken at runtime" class that took
+f311x down in the 2026-06-11 incident. Each now has a `bin/smoke-local.ts`, a `smoke` mise
+task (`depends = ["build"]`), and a CI `smoke` job mirroring the `vitest` one. The boot
+method follows the stack: `astro preview` for the static onvibes.org; `vite preview` for
+revision.city/startchi.com, whose `@cloudflare/vite-plugin` serves the SSR worker in workerd;
+and a config-driven `wrangler dev` for monicandavid.com (SvelteKit) and pkg.dog (Nuxt),
+because their framework `preview` commands either serve the app under Node (SvelteKit's
+`vite preview`) or wrap wrangler in a child process that survives teardown (Nuxt's
+`nuxt preview`) — booting the real `_worker.js` / `.output` artifact under workerd is the
+only faithful gate, with the worker entry, assets, and compatibility settings read from each
+app's `wrangler.toml`. The two `tsgo`-checked apps (revision.city, startchi.com) also gained
+`@types/bun` so their now-typechecked `bin/` resolves the Bun globals, matching forzamonica.com.
+
 ## 2026-06-16
 
 ### chore(tooling): enforce cspell repo-wide; fix `.prettierignore`; bump Biome; add tooling standard


### PR DESCRIPTION
## Summary

Add pre-merge smoke tests to the five scaffolded deployed sites (onvibes.org, revision.city, startchi.com, monicandavid.com, pkg.dog). Each now boots its production build locally and asserts the critical path serves — catching the "green CI, broken at runtime" class before merge.

## Changes

- Added `bin/smoke-local.ts` to each of the five apps, implementing a runtime gate that:
  - Boots the production build using the appropriate tool for each stack (astro preview, vite preview, or wrangler dev)
  - Verifies critical routes return 200 and serve complete HTML documents
  - Validates that hashed client assets referenced in the HTML also serve successfully
  - Properly tears down the server process to release the port

- Added `smoke` mise task to each app's `mise.toml` (depends on `build`, runs `bun bin/smoke-local.ts`)

- Added `smoke` CI job to each app's GitHub Actions workflow, mirroring the `vitest` job structure

- Added `@types/bun` to revision.city and startchi.com devDependencies so their `bin/` scripts resolve Bun globals with type checking

- Updated changelog with rationale: each framework's preview command either serves under Node (SvelteKit) or wraps wrangler in a child process that survives teardown (Nuxt), so booting the real worker artifact under workerd via direct wrangler invocation is the only faithful gate

## Changelog entry

```markdown
### test(apps): runtime smoke gates for the five deployed scaffolded sites

The five scaffolded sites (onvibes.org, revision.city, startchi.com, monicandavid.com,
pkg.dog) had shipped to Cloudflare since 2026-06-14 with no runtime gate — a violation of
the CLAUDE.md contract that every deployed app boot its production build locally and assert
the critical path serves, and exactly the "green CI, broken at runtime" class that took
f311x down in the 2026-06-11 incident. Each now has a `bin/smoke-local.ts`, a `smoke` mise
task (`depends = ["build"]`), and a CI `smoke` job mirroring the `vitest` one. The boot
method follows the stack: `astro preview` for the static onvibes.org; `vite preview` for
revision.city/startchi.com, whose `@cloudflare/vite-plugin` serves the SSR worker in workerd;
and a config-driven `wrangler dev` for monicandavid.com (SvelteKit) and pkg.dog (Nuxt),
because their framework `preview` commands either serve the app under Node (SvelteKit's
`vite preview`) or wrap wrangler in a child process that survives teardown (Nuxt's
`nuxt preview`) — booting the real `_worker.js` / `.output` artifact under workerd is the
only faithful gate, with the worker entry, assets, and compatibility settings read from each
app's `wrangler.toml`. The two `tsgo`-checked apps (revision.city, startchi.com) also gained
`@types/bun` so their now-typechecked `bin/` resolves the Bun globals, matching forzamonica.com.
```

## Testing

- [ ] Builds successfully
- [ ] Tests pass
- [ ] CI smoke jobs pass on all five apps

https://claude.ai/code/session_01EpXAbMpDeULaWTMUrNhJpN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and local test tooling only; no production app logic, auth, or deploy behavior changes beyond new gates.
> 
> **Overview**
> Adds **pre-merge runtime smoke gates** for onvibes.org, revision.city, startchi.com, monicandavid.com, and pkg.dog — each boots a **production build** locally and asserts configured routes return 200, serve complete HTML, and that referenced hashed JS/CSS assets load.
> 
> Each app gets `bin/smoke-local.ts`, a **`smoke` mise task** (`depends = ["build"]`, `bun bin/smoke-local.ts`), and a matching **`smoke` CI job** (15-minute timeout) in its workflow. Boot path is stack-specific: **`astro preview`** for static onvibes.org; **`vite preview`** for TanStack Start apps (with extra checks that reject dev virtual entries and require hashed assets); **`wrangler dev`** directly for SvelteKit and Nuxt so workerd runs the shipped worker artifact and teardown kills the process cleanly. Scripts use **`SMOKE_ROUTES`** / **`SMOKE_PORT`** and spawn preview binaries directly (not via `pnpm`) so ports release after CI.
> 
> **revision.city** and **startchi.com** add **`@types/bun`** (and lockfile updates) so `bin/` typechecks under tsgo. Changelog documents the rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fcc181299583c7797b42218295c3d80d7dc796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->