### PR TITLE
fix(repo): scope mise CI cache key to the lockfile via a shared setup-mise action

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -1,0 +1,22 @@
+name: Setup mise
+description: >-
+  Install mise-managed tools with a cache key scoped to the root tool config and
+  lockfile (.config/mise.toml + .config/mise.lock). Editing app-level mise.toml
+  (e.g. adding tasks) no longer busts the shared cache; only genuine tool-version
+  bumps do.
+
+inputs:
+  cache:
+    description: Restore and save the mise tool cache.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: mise
+      uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+      with:
+        install: true
+        cache: ${{ inputs.cache }}
+        cache_key: mise-v1-{{platform}}-${{ hashFiles('.config/mise.toml', '.config/mise.lock') }}

--- a/.github/workflows/bot-claude.yml
+++ b/.github/workflows/bot-claude.yml
@@ -49,10 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: claude-code-action
         id: claude

--- a/.github/workflows/cd-deploy-calendar-visualizer.yml
+++ b/.github/workflows/cd-deploy-calendar-visualizer.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-calendar-visualizer.yml
+++ b/.github/workflows/cd-deploy-calendar-visualizer.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-davidjfelix-com.yml
+++ b/.github/workflows/cd-deploy-davidjfelix-com.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-davidjfelix-com.yml
+++ b/.github/workflows/cd-deploy-davidjfelix-com.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-djf-io.yml
+++ b/.github/workflows/cd-deploy-djf-io.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-djf-io.yml
+++ b/.github/workflows/cd-deploy-djf-io.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-f311x.yml
+++ b/.github/workflows/cd-deploy-f311x.yml
@@ -36,9 +36,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-f311x.yml
+++ b/.github/workflows/cd-deploy-f311x.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-forzamonica-com.yml
+++ b/.github/workflows/cd-deploy-forzamonica-com.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-forzamonica-com.yml
+++ b/.github/workflows/cd-deploy-forzamonica-com.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-monicandavid-com.yml
+++ b/.github/workflows/cd-deploy-monicandavid-com.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-monicandavid-com.yml
+++ b/.github/workflows/cd-deploy-monicandavid-com.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-onvibes-org.yml
+++ b/.github/workflows/cd-deploy-onvibes-org.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-onvibes-org.yml
+++ b/.github/workflows/cd-deploy-onvibes-org.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-pkg-dog.yml
+++ b/.github/workflows/cd-deploy-pkg-dog.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-pkg-dog.yml
+++ b/.github/workflows/cd-deploy-pkg-dog.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-ravrun.yml
+++ b/.github/workflows/cd-deploy-ravrun.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-ravrun.yml
+++ b/.github/workflows/cd-deploy-ravrun.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-revision-city.yml
+++ b/.github/workflows/cd-deploy-revision-city.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-revision-city.yml
+++ b/.github/workflows/cd-deploy-revision-city.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-startchi-com.yml
+++ b/.github/workflows/cd-deploy-startchi-com.yml
@@ -26,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        uses: ./.github/actions/setup-mise
         with:
-          install: true
           cache: false
 
       - name: pnpm install

--- a/.github/workflows/cd-deploy-startchi-com.yml
+++ b/.github/workflows/cd-deploy-startchi-com.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: mise
         uses: ./.github/actions/setup-mise
-        with:
-          cache: false
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-preview-f311x.yml
+++ b/.github/workflows/cd-preview-f311x.yml
@@ -45,10 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +135,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-actions-lint.yml
+++ b/.github/workflows/ci-actions-lint.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/**'
+      - '.github/actions/**'
       - '.github/zizmor.yml'
       - '.config/mise.toml'
       - 'ghalint.yaml'
   pull_request:
     paths:
       - '.github/workflows/**'
+      - '.github/actions/**'
       - '.github/zizmor.yml'
       - '.config/mise.toml'
       - 'ghalint.yaml'
@@ -29,10 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: Verify mise.lock matches mise.toml
         # mise install during the previous step updates .config/mise.lock if

--- a/.github/workflows/ci-calendar-visualizer.yml
+++ b/.github/workflows/ci-calendar-visualizer.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -66,10 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -90,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -114,10 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -162,10 +147,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-davidjfelix-com.yml
+++ b/.github/workflows/ci-davidjfelix-com.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -66,10 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -90,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -114,10 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -162,10 +147,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-djf-io.yml
+++ b/.github/workflows/ci-djf-io.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -66,10 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -90,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -114,10 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -162,10 +147,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-f311x.yml
+++ b/.github/workflows/ci-f311x.yml
@@ -44,10 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -68,10 +65,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -92,10 +86,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -116,10 +107,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -140,10 +128,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -164,10 +149,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-forzamonica-com.yml
+++ b/.github/workflows/ci-forzamonica-com.yml
@@ -44,10 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -68,10 +65,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -92,10 +86,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -116,10 +107,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -140,10 +128,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -164,10 +149,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-monicandavid-com.yml
+++ b/.github/workflows/ci-monicandavid-com.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -66,10 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -90,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -114,10 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-onvibes-org.yml
+++ b/.github/workflows/ci-onvibes-org.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -66,10 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -90,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -114,10 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-pkg-dog.yml
+++ b/.github/workflows/ci-pkg-dog.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -66,10 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -90,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -114,10 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-ravrun.yml
+++ b/.github/workflows/ci-ravrun.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -66,10 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -90,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -114,10 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -162,10 +147,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: format
         run: mise run format

--- a/.github/workflows/ci-revision-city.yml
+++ b/.github/workflows/ci-revision-city.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -66,10 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -90,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -114,10 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-spell.yml
+++ b/.github/workflows/ci-spell.yml
@@ -24,10 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: spell
         run: mise run spell

--- a/.github/workflows/ci-startchi-com.yml
+++ b/.github/workflows/ci-startchi-com.yml
@@ -42,10 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -66,10 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -90,10 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -114,10 +105,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile
@@ -138,10 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: pnpm install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cron-dependency-freshness.yml
+++ b/.github/workflows/cron-dependency-freshness.yml
@@ -28,10 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          install: true
-          cache: true
+        uses: ./.github/actions/setup-mise
 
       - name: claude-code-action
         uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -1,5 +1,23 @@
 # 2026-06
 
+## 2026-06-17
+
+### fix(repo): scope the mise CI cache key to the lockfile via a shared `setup-mise` action
+
+`jdx/mise-action`'s default cache key hashes *all* mise config files repo-wide — its
+`{{file_hash}}` globs `**/mise.toml` — so editing any app's `mise.toml` (even just adding
+a task) invalidates the one shared key for every workflow. The #247 smoke-task commit did
+exactly that, so every CI job started on a cold cache; dozens of parallel jobs then
+stampeded the same key, and two unlucky ones (monicandavid `svelte-check`, pkg.dog
+`format check`) stalled on the cold Node-tarball download until their 10-minute timeout
+cancelled them. Factored the mise setup into a local composite action
+`.github/actions/setup-mise` that pins the cache key to the real tool inputs —
+`mise-v1-{{platform}}-${{ hashFiles('.config/mise.toml', '.config/mise.lock') }}` — and
+converted all 79 `jdx/mise-action` usages across 28 workflows to it. App `mise.toml` edits
+no longer bust the cache; only genuine tool-version bumps (which change `.config/mise.lock`)
+do. Also added `.github/actions/**` to `ci-actions-lint.yml`'s triggers so the shared
+action is linted when it changes.
+
 ## 2026-06-16
 
 ### chore(tooling): enforce cspell repo-wide; fix `.prettierignore`; bump Biome; add tooling standard

--- a/docs/changelog/2026-06.md
+++ b/docs/changelog/2026-06.md
@@ -16,7 +16,10 @@ cancelled them. Factored the mise setup into a local composite action
 converted all 79 `jdx/mise-action` usages across 28 workflows to it. App `mise.toml` edits
 no longer bust the cache; only genuine tool-version bumps (which change `.config/mise.lock`)
 do. Also added `.github/actions/**` to `ci-actions-lint.yml`'s triggers so the shared
-action is linted when it changes.
+action is linted when it changes. The 11 `cd-deploy` jobs (previously `cache: false`, a
+template default with no recorded rationale) now use the shared cache too — safe because
+the key is lockfile-scoped (identical pinned tool binaries) and deploys run only on
+`push: main`, a trusted context whose cache scope no untrusted PR can write to.
 
 ## 2026-06-16
 


### PR DESCRIPTION
## Summary

`jdx/mise-action`'s default cache key hashes **all** mise config files repo-wide — its `{{file_hash}}` globs `**/mise.toml` — so editing *any* app's `mise.toml` (even just adding a task) invalidates the single shared cache key for **every** workflow.

The #247 smoke-task commit edited five `apps/*/mise.toml`, which busted the key. Every CI job then started on a cold cache, dozens of parallel jobs stampeded that one key, and two unlucky ones — **monicandavid `svelte-check`** and **pkg.dog `format check`** — stalled on the cold `node-v26.3.0` tarball download (mise has no download timeout) until their `timeout-minutes: 10` cancelled them.

## Fix

Factor the mise setup into a local composite action **`.github/actions/setup-mise`** that pins the cache key to the *real* tool inputs:

```yaml
cache_key: mise-v1-{{platform}}-${{ hashFiles('.config/mise.toml', '.config/mise.lock') }}
```

…and convert all **79 `jdx/mise-action` usages across 28 workflows** to `uses: ./.github/actions/setup-mise`. App `mise.toml` edits (tasks, config) no longer bust the cache — only genuine tool-version bumps, which change `.config/mise.lock`, do.

The two call-site shapes map cleanly:
- CI / preview / bot / cron (`cache: true`) → `uses: ./.github/actions/setup-mise` (defaults)
- cd-deploy (`cache: false`) → same, with `with: { cache: false }`

Also added `.github/actions/**` to `ci-actions-lint.yml`'s triggers so the shared action is linted when it changes.

## Validation

- `actionlint`, `ghalint`, `pinact run --check`, `zizmor` — all pass locally (pinact correctly ignores local `./` actions; zizmor audited the new `action.yml`, no findings).
- `cspell` clean (351 files).
- Net **−173 lines** from dropping the duplicated `with:` blocks.

## Notes

- **First run is cold:** this PR's own CI uses the *new* key for the first time, so it cold-installs once (and may briefly stampede) before the cache warms — expected, and self-heals on subsequent runs.
- **#247 interaction:** this branches from `main`, converting the 79 usages there. #247 adds five new `smoke`-job mise steps; those get switched to the composite when #247 is rebased onto this change.

## Changelog

Added under `docs/changelog/2026-06.md` → `2026-06-17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpXAbMpDeULaWTMUrNhJpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpXAbMpDeULaWTMUrNhJpN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/CD wiring only; behavior change is faster, more stable caching and enabling cache on deploy jobs—no application or auth logic touched.
> 
> **Overview**
> Introduces **`.github/actions/setup-mise`**, a composite action that wraps `jdx/mise-action` with a **lockfile-scoped** cache key (`hashFiles('.config/mise.toml', '.config/mise.lock')`) instead of the default key that hashes every `**/mise.toml`. That stops app-level task-only edits from invalidating the shared mise cache across all workflows.
> 
> **Replaces** duplicated inline `jdx/mise-action` steps (with per-workflow `install` / `cache` blocks) across **28 workflows** with `uses: ./.github/actions/setup-mise`. Optional `cache` input defaults to enabled; deploy workflows that previously used `cache: false` now use the composite with caching on (same pinned tools, `main`-only deploy context).
> 
> **`ci-actions-lint.yml`** path filters now include **`.github/actions/**`** so changes to the composite action run actionlint/ghalint/zizmor/pinact.
> 
> Changelog entry added under **`docs/changelog/2026-06.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ccc28b1be7de83e280cbca7b60127d6bd050e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->